### PR TITLE
Fix CORS preflight requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 // Library imports
 const express = require('express');
-const cors = require('cors');
 const compress = require('compression');
 const Sentry = require('@sentry/node');
 const morgan = require('morgan');
@@ -8,6 +7,7 @@ const morgan = require('morgan');
 // Local imports
 const librariesUtil = require('./utils/libraries');
 const cacheUtil = require('./utils/cache');
+const cors = require('./utils/cors');
 
 // Routes imports
 const librariesRoutes = require('./routes/libraries');
@@ -50,12 +50,7 @@ module.exports = () => {
     librariesUtil.set(app);
 
     // Set up cors headers
-    app.use(cors({
-        origin: '*',
-        credentials: true,
-        methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
-        allowedHeaders: ['X-CSRF-Token', 'X-Requested-With', 'Accept', 'Accept-Version', 'Content-Length', 'Content-MD5', 'Content-Type', 'Date', 'X-Api-Version'],
-    }));
+    cors(app);
 
     if (!localMode) {
         app.use((req, res, next) => {

--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 // Library imports
 const express = require('express');
+const cors = require('cors');
 const compress = require('compression');
 const Sentry = require('@sentry/node');
 const morgan = require('morgan');
@@ -48,17 +49,20 @@ module.exports = () => {
     // Load the library data
     librariesUtil.set(app);
 
-    // Set all the relevant headers for the app
-    app.use((req, res, next) => {
-        res.header('Access-Control-Allow-Credentials', true);
-        res.header('Access-Control-Allow-Origin', '*');
-        res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,OPTIONS');
-        res.header('Access-Control-Allow-Headers', 'X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version');
-        if (!localMode) {
+    // Set up cors headers
+    app.use(cors({
+        origin: '*',
+        credentials: true,
+        methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
+        allowedHeaders: ['X-CSRF-Token', ' X-Requested-With', ' Accept', ' Accept-Version', ' Content-Length', ' Content-MD5', ' Content-Type', ' Date', ' X-Api-Version'],
+    }));
+
+    if (!localMode) {
+        app.use((req, res, next) => {
             res.setHeader('Public-Key-Pins', 'pin-sha256="EULHwYvGhknyznoBvyvgbidiBH3JX3eFHHlIO3YK8Ek=";pin-sha256="x9SZw6TwIqfmvrLZ/kz1o0Ossjmn728BnBKpUFqGNVM=";max-age=3456000;report-uri="https://cdnjs.report-uri.io/r/default/hpkp/enforce"');
-        }
-        next();
-    });
+            next();
+        });
+    }
 
     // Always compress whatever we return
     app.use(compress());

--- a/app.js
+++ b/app.js
@@ -54,7 +54,7 @@ module.exports = () => {
         origin: '*',
         credentials: true,
         methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
-        allowedHeaders: ['X-CSRF-Token', ' X-Requested-With', ' Accept', ' Accept-Version', ' Content-Length', ' Content-MD5', ' Content-Type', ' Date', ' X-Api-Version'],
+        allowedHeaders: ['X-CSRF-Token', 'X-Requested-With', 'Accept', 'Accept-Version', 'Content-Length', 'Content-MD5', 'Content-Type', 'Date', 'X-Api-Version'],
     }));
 
     if (!localMode) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -715,6 +715,15 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
             "dev": true
         },
+        "cors": {
+            "version": "2.8.5",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+            "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+            "requires": {
+                "object-assign": "^4",
+                "vary": "^1"
+            }
+        },
         "cross-spawn": {
             "version": "6.0.5",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -1915,6 +1924,11 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-inspect": {
             "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
     "description": "The new API server for api.cdnjs.com",
     "private": true,
     "main": "index.js",
-    "engines" : {
-        "node" : "12.16.2"
+    "engines": {
+        "node": "12.16.2"
     },
     "scripts": {
         "test": "npm run test:echint && npm run test:eslint && npm run test:mocha",
@@ -33,6 +33,7 @@
         "algoliasearch": "^4.1.0",
         "body-parser": "^1.19.0",
         "compression": "^1.7.4",
+        "cors": "^2.8.5",
         "express": "^4.17.1",
         "morgan": "^1.10.0"
     },

--- a/tests/cors.js
+++ b/tests/cors.js
@@ -21,7 +21,7 @@ const testCors = (path, getResponse) => {
         done();
     });
 
-    it('returns the correct CORS headers for OPTIONS request', (done) => {
+    it('returns the correct CORS headers for OPTIONS request', done => {
         request()
             .options(path)
             .redirects(0)

--- a/tests/cors.js
+++ b/tests/cors.js
@@ -8,7 +8,7 @@ const expectCORSHeaders = (response) => {
     expect(response).to.have.header('Access-Control-Allow-Credentials', corsOptions.credentials.toString());
 
     // testing allowed methods and headers only makes sense in case of options
-    if (response.request.method.toLowerCase === 'options') {
+    if (response.request.method.toLowerCase() === 'options') {
         expect(response).to.have.header('Access-Control-Allow-Headers', corsOptions.allowedHeaders.join(','));
         expect(response).to.have.header('Access-Control-Allow-Methods', corsOptions.methods.join(','));
     }

--- a/tests/cors.js
+++ b/tests/cors.js
@@ -3,7 +3,7 @@ const { expect } = require('chai');
 const request = require('./base');
 const { corsOptions } = require('../utils/cors');
 
-const expectCORSHeaders = (response) => {
+const expectCORSHeaders = response => {
     expect(response).to.have.header('Access-Control-Allow-Origin', corsOptions.origin);
     expect(response).to.have.header('Access-Control-Allow-Credentials', corsOptions.credentials.toString());
 

--- a/tests/cors.js
+++ b/tests/cors.js
@@ -1,0 +1,37 @@
+const { it } = require('mocha');
+const { expect } = require('chai');
+const request = require('./base');
+const { corsOptions } = require('../utils/cors');
+
+const expectCORSHeaders = (response) => {
+    expect(response).to.have.header('Access-Control-Allow-Origin', corsOptions.origin);
+    expect(response).to.have.header('Access-Control-Allow-Credentials', corsOptions.credentials.toString());
+
+    // testing allowed methods and headers only makes sense in case of options
+    if (response.request.method.toLowerCase === 'options') {
+        expect(response).to.have.header('Access-Control-Allow-Headers', corsOptions.allowedHeaders.join(','));
+        expect(response).to.have.header('Access-Control-Allow-Methods', corsOptions.methods.join(','));
+    }
+};
+
+const testCors = (path, getResponse) => {
+    it('returns the correct CORS headers', done => {
+        const response = getResponse();
+        expectCORSHeaders(response);
+        done();
+    });
+
+    it('returns the correct CORS headers for OPTIONS request', (done) => {
+        request()
+            .options(path)
+            .redirects(0)
+            .end((err, res) => {
+                const expectedStatus = corsOptions.optionsSuccessStatus;
+                expect(res.status).to.equal(expectedStatus, `Expected OPTIONS to return ${expectedStatus} status, got ${res.status}`);
+                expectCORSHeaders(res);
+                done();
+            });
+    });
+};
+
+module.exports = testCors;

--- a/tests/cors.js
+++ b/tests/cors.js
@@ -26,8 +26,7 @@ const testCors = (path, getResponse) => {
             .options(path)
             .redirects(0)
             .end((err, res) => {
-                const expectedStatus = corsOptions.optionsSuccessStatus;
-                expect(res.status).to.equal(expectedStatus, `Expected OPTIONS to return ${expectedStatus} status, got ${res.status}`);
+                expect(res).to.have.status(corsOptions.optionsSuccessStatus);
                 expectCORSHeaders(res);
                 done();
             });

--- a/tests/cors.js
+++ b/tests/cors.js
@@ -7,7 +7,7 @@ const expectCORSHeaders = response => {
     expect(response).to.have.header('Access-Control-Allow-Origin', corsOptions.origin);
     expect(response).to.have.header('Access-Control-Allow-Credentials', corsOptions.credentials.toString());
 
-    // testing allowed methods and headers only makes sense in case of options
+    // Testing allowed methods and headers only makes sense in case of options
     if (response.request.method.toLowerCase() === 'options') {
         expect(response).to.have.header('Access-Control-Allow-Headers', corsOptions.allowedHeaders.join(','));
         expect(response).to.have.header('Access-Control-Allow-Methods', corsOptions.methods.join(','));

--- a/tests/suite/index.js
+++ b/tests/suite/index.js
@@ -1,6 +1,7 @@
 const { describe, it, before } = require('mocha');
 const { expect } = require('chai');
 const request = require('../base');
+const testCors = require('../cors');
 
 describe('/', () => {
     const test = () => request().get('/').redirects(0);
@@ -11,16 +12,12 @@ describe('/', () => {
             done();
         });
     });
-    it('returns the correct CORS and Cache headers', done => {
-        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+
+    testCors('/', () => response);
+
+    it('returns the correct Cache headers', done => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
         done();
-    });
-    it('returns the correct CORS headers for OPTIONS', done => {
-        request().options('/').redirects(0).end((err, res) => {
-            expect(res).to.have.header('Access-Control-Allow-Origin', '*');
-            done();
-        });
     });
     it('redirects to the cdnjs.com API docs as a 301', done => {
         expect(response).to.have.status(301);

--- a/tests/suite/index.js
+++ b/tests/suite/index.js
@@ -35,8 +35,10 @@ describe('/this-route-doesnt-exist', () => {
             done();
         });
     });
-    it('returns the correct CORS and Cache headers', done => {
-        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+
+    testCors('/', () => response);
+
+    it('returns the correct Cache headers', done => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
         done();
     });

--- a/tests/suite/index.js
+++ b/tests/suite/index.js
@@ -16,6 +16,13 @@ describe('/', () => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
         done();
     });
+    it('returns the correct CORS and Cache headers for OPTIONS', done => {
+        request().options('/').redirects(0).end((err, res) => {
+            expect(res).to.have.header('Access-Control-Allow-Origin', '*');
+            expect(res).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
+            done();
+        });
+    });
     it('redirects to the cdnjs.com API docs as a 301', done => {
         expect(response).to.have.status(301);
         expect(response).to.redirectTo('https://cdnjs.com/api');

--- a/tests/suite/index.js
+++ b/tests/suite/index.js
@@ -4,7 +4,8 @@ const request = require('../base');
 const testCors = require('../cors');
 
 describe('/', () => {
-    const test = () => request().get('/').redirects(0);
+    const path = '/';
+    const test = () => request().get(path).redirects(0);
     let response;
     before('fetch endpoint', done => {
         test().end((err, res) => {
@@ -13,7 +14,7 @@ describe('/', () => {
         });
     });
 
-    testCors('/', () => response);
+    testCors(path, () => response);
 
     it('returns the correct Cache headers', done => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
@@ -27,7 +28,8 @@ describe('/', () => {
 });
 
 describe('/this-route-doesnt-exist', () => {
-    const test = () => request().get('/this-route-doesnt-exist');
+    const path = '/this-route-doesnt-exist';
+    const test = () => request().get(path);
     let response;
     before('fetch endpoint', done => {
         test().end((err, res) => {
@@ -36,7 +38,7 @@ describe('/this-route-doesnt-exist', () => {
         });
     });
 
-    testCors('/', () => response);
+    testCors(path, () => response);
 
     it('returns the correct Cache headers', done => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour

--- a/tests/suite/index.js
+++ b/tests/suite/index.js
@@ -16,10 +16,9 @@ describe('/', () => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
         done();
     });
-    it('returns the correct CORS and Cache headers for OPTIONS', done => {
+    it('returns the correct CORS headers for OPTIONS', done => {
         request().options('/').redirects(0).end((err, res) => {
             expect(res).to.have.header('Access-Control-Allow-Origin', '*');
-            expect(res).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
             done();
         });
     });

--- a/tests/suite/index.js
+++ b/tests/suite/index.js
@@ -13,9 +13,7 @@ describe('/', () => {
             done();
         });
     });
-
     testCors(path, () => response);
-
     it('returns the correct Cache headers', done => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
         done();
@@ -37,9 +35,7 @@ describe('/this-route-doesnt-exist', () => {
             done();
         });
     });
-
     testCors(path, () => response);
-
     it('returns the correct Cache headers', done => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
         done();

--- a/tests/suite/libraries.js
+++ b/tests/suite/libraries.js
@@ -1,13 +1,15 @@
 const { describe, it, before } = require('mocha');
 const { expect } = require('chai');
 const request = require('../base');
+const testCors = require('../cors');
 
 describe('/libraries', function () {
     // This route is a bit slower due to Algolia
     this.timeout(5000);
 
     describe('No query params', () => {
-        const test = () => request().get('/libraries');
+        const path = '/libraries';
+        const test = () => request().get(path);
         let response;
         before('fetch endpoint', done => {
             test().end((err, res) => {
@@ -15,6 +17,7 @@ describe('/libraries', function () {
                 done();
             });
         });
+        testCors(path, () => response);
         it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
             done();
@@ -55,7 +58,8 @@ describe('/libraries', function () {
     });
 
     describe('Limiting number of results (?limit=10)', () => {
-        const test = () => request().get('/libraries?limit=10');
+        const path = '/libraries?limit=10';
+        const test = () => request().get(path);
         let response;
         before('fetch endpoint', done => {
             test().end((err, res) => {
@@ -63,6 +67,7 @@ describe('/libraries', function () {
                 done();
             });
         });
+        testCors(path, () => response);
         it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
             done();
@@ -83,7 +88,8 @@ describe('/libraries', function () {
     });
 
     describe('Requesting a field (?fields=version)', () => {
-        const test = () => request().get('/libraries?fields=version');
+        const path = '/libraries?fields=version';
+        const test = () => request().get(path);
         let response;
         before('fetch endpoint', done => {
             test().end((err, res) => {
@@ -91,6 +97,7 @@ describe('/libraries', function () {
                 done();
             });
         });
+        testCors(path, () => response);
         it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
             done();
@@ -126,7 +133,8 @@ describe('/libraries', function () {
     });
 
     describe('Requesting all fields (?fields=*)', () => {
-        const test = () => request().get('/libraries?fields=*');
+        const path = '/libraries?fields=*';
+        const test = () => request().get(path);
         let response;
         before('fetch endpoint', done => {
             test().end((err, res) => {
@@ -134,6 +142,7 @@ describe('/libraries', function () {
                 done();
             });
         });
+        testCors(path, () => response);
         it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
             done();
@@ -189,7 +198,8 @@ describe('/libraries', function () {
         // TODO: Make this set of tests more robust
 
         describe('Providing a short query (?search=hi-sven)', () => {
-            const test = () => request().get('/libraries?search=hi-sven');
+            const path = '/libraries?search=hi-sven';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -235,7 +245,8 @@ describe('/libraries', function () {
         });
 
         describe('Providing a query that is longer than max that Algolia allows (?search=this-is-a-very-very-long-query-that-algolia-wont-like-and-will-return-an-error-for-as-it-is-longer-that-512-chars-which-is-documented-on-their-website-on-the-query-api-parameters-page-in-the-usage-notes-section-now-i-shall-repeat-this-as-it-isnt-quite-long-enough-to-cause-that-error-yet-this-is-a-very-very-long-query-that-algolia-wont-like-and-will-return-an-error-for-as-it-is-longer-that-512-chars-which-is-documented-on-their-website-on-the-query-api-parameters-page-in-the-usage-notes-section-now-i-shall-repeat-this-as-it-isnt-quite-long-enough-to-cause-that-error-yet)', () => {
-            const test = () => request().get('/libraries?search=this-is-a-very-very-long-query-that-algolia-wont-like-and-will-return-an-error-for-as-it-is-longer-that-512-chars-which-is-documented-on-their-website-on-the-query-api-parameters-page-in-the-usage-notes-section-now-i-shall-repeat-this-as-it-isnt-quite-long-enough-to-cause-that-error-yet-this-is-a-very-very-long-query-that-algolia-wont-like-and-will-return-an-error-for-as-it-is-longer-that-512-chars-which-is-documented-on-their-website-on-the-query-api-parameters-page-in-the-usage-notes-section-now-i-shall-repeat-this-as-it-isnt-quite-long-enough-to-cause-that-error-yet');
+            const path = '/libraries?search=this-is-a-very-very-long-query-that-algolia-wont-like-and-will-return-an-error-for-as-it-is-longer-that-512-chars-which-is-documented-on-their-website-on-the-query-api-parameters-page-in-the-usage-notes-section-now-i-shall-repeat-this-as-it-isnt-quite-long-enough-to-cause-that-error-yet-this-is-a-very-very-long-query-that-algolia-wont-like-and-will-return-an-error-for-as-it-is-longer-that-512-chars-which-is-documented-on-their-website-on-the-query-api-parameters-page-in-the-usage-notes-section-now-i-shall-repeat-this-as-it-isnt-quite-long-enough-to-cause-that-error-yet';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -270,7 +281,8 @@ describe('/libraries', function () {
         // TODO: Make this set of tests more robust
 
         describe('Providing search fields that are valid (?search=backbone.js&search_fields=keywords)', () => {
-            const test = () => request().get('/libraries?search=backbone.js&search_fields=keywords');
+            const path = '/libraries?search=backbone.js&search_fields=keywords';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -320,7 +332,8 @@ describe('/libraries', function () {
 
         describe('Providing search fields that are invalid (?search=backbone.js&search_fields=this-field-doesnt-exist)', () => {
             // If invalid fields make it to Aloglia, it will error, so this tests that we're filtering them first
-            const test = () => request().get('/libraries?search=backbone.js&search_fields=this-field-doesnt-exist');
+            const path = '/libraries?search=backbone.js&search_fields=this-field-doesnt-exist';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {

--- a/tests/suite/libraries.js
+++ b/tests/suite/libraries.js
@@ -15,8 +15,7 @@ describe('/libraries', function () {
                 done();
             });
         });
-        it('returns the correct CORS and Cache headers', done => {
-            expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+        it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
             done();
         });
@@ -64,8 +63,7 @@ describe('/libraries', function () {
                 done();
             });
         });
-        it('returns the correct CORS and Cache headers', done => {
-            expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+        it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
             done();
         });
@@ -93,8 +91,7 @@ describe('/libraries', function () {
                 done();
             });
         });
-        it('returns the correct CORS and Cache headers', done => {
-            expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+        it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
             done();
         });
@@ -137,8 +134,7 @@ describe('/libraries', function () {
                 done();
             });
         });
-        it('returns the correct CORS and Cache headers', done => {
-            expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+        it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
             done();
         });
@@ -201,8 +197,7 @@ describe('/libraries', function () {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                 done();
             });
@@ -248,8 +243,7 @@ describe('/libraries', function () {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                 done();
             });
@@ -284,8 +278,7 @@ describe('/libraries', function () {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                 done();
             });
@@ -335,8 +328,7 @@ describe('/libraries', function () {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                 done();
             });

--- a/tests/suite/libraries.js
+++ b/tests/suite/libraries.js
@@ -134,7 +134,8 @@ describe('/libraries', function () {
 
     describe('Requesting multiple fields', () => {
         describe('through comma-separated string (?fields=filename,version)', () => {
-            const test = () => request().get('/libraries?fields=filename,version');
+            const path = '/libraries?fields=filename,version';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -142,8 +143,8 @@ describe('/libraries', function () {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            testCors(path, () => response);
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                 done();
             });
@@ -179,7 +180,8 @@ describe('/libraries', function () {
         });
 
         describe('through multiple query parameters (?fields=filename&fields=version)', () => {
-            const test = () => request().get('/libraries?fields=filename&fields=version');
+            const path = '/libraries?fields=filename&fields=version';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -187,8 +189,8 @@ describe('/libraries', function () {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            testCors(path, () => response);
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                 done();
             });
@@ -299,6 +301,7 @@ describe('/libraries', function () {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                 done();
@@ -346,6 +349,7 @@ describe('/libraries', function () {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                 done();
@@ -375,7 +379,8 @@ describe('/libraries', function () {
 
         describe('Providing search fields that are valid', () => {
             describe('through comma-separated string (?search=backbone.js&search_fields=keywords,github.user)', () => {
-                const test = () => request().get('/libraries?search=backbone.js&search_fields=keywords,github.user');
+                const path = '/libraries?search=backbone.js&search_fields=keywords,github.user';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -383,8 +388,8 @@ describe('/libraries', function () {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                     done();
                 });
@@ -426,7 +431,8 @@ describe('/libraries', function () {
             });
 
             describe('through multiple query parameters (?search=backbone.js&search_fields=keywords&search_fields=github.user)', () => {
-                const test = () => request().get('/libraries?search=backbone.js&search_fields=keywords&search_fields=github.user');
+                const path = '/libraries?search=backbone.js&search_fields=keywords&search_fields=github.user';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -434,8 +440,8 @@ describe('/libraries', function () {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                     done();
                 });
@@ -488,6 +494,7 @@ describe('/libraries', function () {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                 done();

--- a/tests/suite/library.js
+++ b/tests/suite/library.js
@@ -1,12 +1,14 @@
 const { describe, it, before } = require('mocha');
 const { expect } = require('chai');
 const request = require('../base');
+const testCors = require('../cors');
 
 describe('/libraries/:library/:version', () => {
     describe('Requesting a valid library (:library = backbone.js)', () => {
         describe('Requesting a valid version (:version = 1.1.0)', () => {
             describe('No query params', () => {
-                const test = () => request().get('/libraries/backbone.js/1.1.0');
+                const path = '/libraries/backbone.js/1.1.0';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -14,6 +16,7 @@ describe('/libraries/:library/:version', () => {
                         done();
                     });
                 });
+                testCors(path, () => response);
                 it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
                     done();
@@ -40,7 +43,8 @@ describe('/libraries/:library/:version', () => {
             });
 
             describe('Requesting a field (?fields=files)', () => {
-                const test = () => request().get('/libraries/backbone.js/1.1.0?fields=files');
+                const path = '/libraries/backbone.js/1.1.0?fields=files';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -48,6 +52,7 @@ describe('/libraries/:library/:version', () => {
                         done();
                     });
                 });
+                testCors(path, () => response);
                 it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
                     done();
@@ -70,7 +75,8 @@ describe('/libraries/:library/:version', () => {
             });
 
             describe('Requesting all fields (?fields=*)', () => {
-                const test = () => request().get('/libraries/backbone.js/1.1.0?fields=*');
+                const path = '/libraries/backbone.js/1.1.0?fields=*';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -78,6 +84,7 @@ describe('/libraries/:library/:version', () => {
                         done();
                     });
                 });
+                testCors(path, () => response);
                 it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
                     done();
@@ -106,7 +113,8 @@ describe('/libraries/:library/:version', () => {
 
         describe('Requesting a non-existent version (:version = this-version-doesnt-exist)', () => {
             describe('No query params', () => {
-                const test = () => request().get('/libraries/backbone.js/this-version-doesnt-exist');
+                const path = '/libraries/backbone.js/this-version-doesnt-exist';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -114,6 +122,7 @@ describe('/libraries/:library/:version', () => {
                         done();
                     });
                 });
+                testCors(path, () => response);
                 it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                     done();
@@ -132,7 +141,8 @@ describe('/libraries/:library/:version', () => {
 
     describe('Requesting a non-existent library (:library = this-library-doesnt-exist)', () => {
         describe('No query params', () => {
-            const test = () => request().get('/libraries/this-library-doesnt-exist');
+            const path = '/libraries/this-library-doesnt-exist';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -159,7 +169,8 @@ describe('/libraries/:library/:version', () => {
 describe('/libraries/:library', () => {
     describe('Requesting a valid library (:library = backbone.js)', () => {
         describe('No query params', () => {
-            const test = () => request().get('/libraries/backbone.js');
+            const path = '/libraries/backbone.js';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -241,7 +252,8 @@ describe('/libraries/:library', () => {
         });
 
         describe('Requesting a field (?fields=assets)', () => {
-            const test = () => request().get('/libraries/backbone.js?fields=assets');
+            const path = '/libraries/backbone.js?fields=assets';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -271,7 +283,8 @@ describe('/libraries/:library', () => {
         });
 
         describe('Requesting all fields (?fields=*)', () => {
-            const test = () => request().get('/libraries/backbone.js?fields=*');
+            const path = '/libraries/backbone.js?fields=*';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -314,7 +327,8 @@ describe('/libraries/:library', () => {
 
     describe('Requesting a non-existent library (:library = this-library-doesnt-exist)', () => {
         describe('No query params', () => {
-            const test = () => request().get('/libraries/this-library-doesnt-exist');
+            const path = '/libraries/this-library-doesnt-exist';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {

--- a/tests/suite/library.js
+++ b/tests/suite/library.js
@@ -76,7 +76,8 @@ describe('/libraries/:library/:version', () => {
 
             describe('Requesting multiple fields', () => {
                 describe('through comma-separated string (?fields=files,sri)', () => {
-                    const test = () => request().get('/libraries/backbone.js/1.1.0?fields=files,sri');
+                    const path = '/libraries/backbone.js/1.1.0?fields=files,sri';
+                    const test = () => request().get(path);
                     let response;
                     before('fetch endpoint', done => {
                         test().end((err, res) => {
@@ -84,8 +85,8 @@ describe('/libraries/:library/:version', () => {
                             done();
                         });
                     });
-                    it('returns the correct CORS and Cache headers', done => {
-                        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    testCors(path, () => response);
+                    it('returns the correct Cache headers', done => {
                         expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
                         done();
                     });
@@ -108,7 +109,8 @@ describe('/libraries/:library/:version', () => {
                 });
 
                 describe('through multiple query parameters (?fields=files&fields=sri)', () => {
-                    const test = () => request().get('/libraries/backbone.js/1.1.0?fields=files&fields=sri');
+                    const path = '/libraries/backbone.js/1.1.0?fields=files&fields=sri';
+                    const test = () => request().get(path);
                     let response;
                     before('fetch endpoint', done => {
                         test().end((err, res) => {
@@ -116,8 +118,8 @@ describe('/libraries/:library/:version', () => {
                             done();
                         });
                     });
-                    it('returns the correct CORS and Cache headers', done => {
-                        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    testCors(path, () => response);
+                    it('returns the correct Cache headers', done => {
                         expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
                         done();
                     });
@@ -216,6 +218,7 @@ describe('/libraries/:library/:version', () => {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                 done();
@@ -244,6 +247,7 @@ describe('/libraries/:library', () => {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                 done();
@@ -327,6 +331,7 @@ describe('/libraries/:library', () => {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                 done();
@@ -350,7 +355,8 @@ describe('/libraries/:library', () => {
 
         describe('Requesting multiple fields', () => {
             describe('through comma-separated string (?fields=name,assets)', () => {
-                const test = () => request().get('/libraries/backbone.js?fields=name,assets');
+                const path = '/libraries/backbone.js?fields=name,assets';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -358,8 +364,8 @@ describe('/libraries/:library', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                     done();
                 });
@@ -382,7 +388,8 @@ describe('/libraries/:library', () => {
             });
 
             describe('through multiple query parameters (?fields=name&fields=assets)', () => {
-                const test = () => request().get('/libraries/backbone.js?fields=name&fields=assets');
+                const path = '/libraries/backbone.js?fields=name&fields=assets';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -390,8 +397,8 @@ describe('/libraries/:library', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                     done();
                 });
@@ -424,6 +431,7 @@ describe('/libraries/:library', () => {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                 done();
@@ -468,6 +476,7 @@ describe('/libraries/:library', () => {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                 done();

--- a/tests/suite/library.js
+++ b/tests/suite/library.js
@@ -14,8 +14,7 @@ describe('/libraries/:library/:version', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
                     done();
                 });
@@ -49,8 +48,7 @@ describe('/libraries/:library/:version', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
                     done();
                 });
@@ -80,8 +78,7 @@ describe('/libraries/:library/:version', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
                     done();
                 });
@@ -117,8 +114,7 @@ describe('/libraries/:library/:version', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                     done();
                 });
@@ -144,8 +140,7 @@ describe('/libraries/:library/:version', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                 done();
             });
@@ -172,8 +167,7 @@ describe('/libraries/:library', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                 done();
             });
@@ -255,8 +249,7 @@ describe('/libraries/:library', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                 done();
             });
@@ -286,8 +279,7 @@ describe('/libraries/:library', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                 done();
             });
@@ -330,8 +322,7 @@ describe('/libraries/:library', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                 done();
             });

--- a/tests/suite/tutorials.js
+++ b/tests/suite/tutorials.js
@@ -1,11 +1,13 @@
 const { describe, it, before } = require('mocha');
 const { expect } = require('chai');
 const request = require('../base');
+const testCors = require('../cors');
 
 describe('/libraries/:library/tutorials', () => {
     describe('Requesting for a valid library (:library = backbone.js)', () => {
         describe('No query params', () => {
-            const test = () => request().get('/libraries/backbone.js/tutorials');
+            const path = '/libraries/backbone.js/tutorials';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -13,6 +15,7 @@ describe('/libraries/:library/tutorials', () => {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
                 done();
@@ -41,7 +44,8 @@ describe('/libraries/:library/tutorials', () => {
         });
 
         describe('Requesting a field (?fields=name)', () => {
-            const test = () => request().get('/libraries/backbone.js/tutorials?fields=name');
+            const path = '/libraries/backbone.js/tutorials?fields=name';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -49,6 +53,7 @@ describe('/libraries/:library/tutorials', () => {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
                 done();
@@ -79,7 +84,8 @@ describe('/libraries/:library/tutorials', () => {
         });
 
         describe('Requesting all fields (?fields=*)', () => {
-            const test = () => request().get('/libraries/backbone.js/tutorials?fields=*');
+            const path = '/libraries/backbone.js/tutorials?fields=*';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -87,6 +93,7 @@ describe('/libraries/:library/tutorials', () => {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
                 done();
@@ -116,7 +123,8 @@ describe('/libraries/:library/tutorials', () => {
 
     describe('Requesting for a non-existent library (:library = this-library-doesnt-exist)', () => {
         describe('No query params', () => {
-            const test = () => request().get('/libraries/this-library-doesnt-exist/tutorials');
+            const path = '/libraries/this-library-doesnt-exist/tutorials';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -124,6 +132,7 @@ describe('/libraries/:library/tutorials', () => {
                     done();
                 });
             });
+            testCors(path, () => response);
             it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                 done();
@@ -144,7 +153,8 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
     describe('Requesting for a valid library (:library = backbone.js)', () => {
         describe('Requesting a valid tutorial (:tutorial = what-is-a-view)', () => {
             describe('No query params', () => {
-                const test = () => request().get('/libraries/backbone.js/tutorials/what-is-a-view');
+                const path = '/libraries/backbone.js/tutorials/what-is-a-view';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -175,7 +185,8 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
             });
 
             describe('Requesting a field (?fields=name)', () => {
-                const test = () => request().get('/libraries/backbone.js/tutorials/what-is-a-view?fields=name');
+                const path = '/libraries/backbone.js/tutorials/what-is-a-view?fields=name';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -205,7 +216,8 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
             });
 
             describe('Requesting all fields (?fields=*)', () => {
-                const test = () => request().get('/libraries/backbone.js/tutorials/what-is-a-view?fields=*');
+                const path = '/libraries/backbone.js/tutorials/what-is-a-view?fields=*';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -239,7 +251,8 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
 
         describe('Requesting a non-existent tutorial (:tutorial = this-tutorial-doesnt-exist)', () => {
             describe('No query params', () => {
-                const test = () => request().get('/libraries/backbone.js/tutorials/this-tutorial-doesnt-exist');
+                const path = '/libraries/backbone.js/tutorials/this-tutorial-doesnt-exist';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -266,7 +279,8 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
     describe('Requesting for a non-existent library (:library = this-library-doesnt-exist)', () => {
         describe('Requesting a non-existent tutorial (:tutorial = this-tutorial-doesnt-exist)', () => {
             describe('No query params', () => {
-                const test = () => request().get('/libraries/this-library-doesnt-exist/tutorials/this-tutorial-doesnt-exist');
+                const path = '/libraries/this-library-doesnt-exist/tutorials/this-tutorial-doesnt-exist';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {

--- a/tests/suite/tutorials.js
+++ b/tests/suite/tutorials.js
@@ -85,7 +85,8 @@ describe('/libraries/:library/tutorials', () => {
 
         describe('Requesting multiple fields', () => {
             describe('through comma-separated string (?fields=name,content)', () => {
-                const test = () => request().get('/libraries/backbone.js/tutorials?fields=name,content');
+                const path = '/libraries/backbone.js/tutorials?fields=name,content';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -93,8 +94,8 @@ describe('/libraries/:library/tutorials', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
                     done();
                 });
@@ -125,7 +126,8 @@ describe('/libraries/:library/tutorials', () => {
             });
 
             describe('through multiple query parameters (?fields=name&fields=content)', () => {
-                const test = () => request().get('/libraries/backbone.js/tutorials?fields=name&fields=content');
+                const path = '/libraries/backbone.js/tutorials?fields=name&fields=content';
+                const test = () => request().get(path);
                 let response;
                 before('fetch endpoint', done => {
                     test().end((err, res) => {
@@ -133,8 +135,8 @@ describe('/libraries/:library/tutorials', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
                     done();
                 });
@@ -246,6 +248,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
+                testCors(path, () => response);
                 it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
                     done();
@@ -278,6 +281,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
+                testCors(path, () => response);
                 it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
                     done();
@@ -301,7 +305,8 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
 
             describe('Requesting multiple fields', () => {
                 describe('through comma-separated string (?fields=name,content)', () => {
-                    const test = () => request().get('/libraries/backbone.js/tutorials/what-is-a-view?fields=name,content');
+                    const path = '/libraries/backbone.js/tutorials/what-is-a-view?fields=name,content';
+                    const test = () => request().get(path);
                     let response;
                     before('fetch endpoint', done => {
                         test().end((err, res) => {
@@ -309,8 +314,8 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                             done();
                         });
                     });
-                    it('returns the correct CORS and Cache headers', done => {
-                        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    testCors(path, () => response);
+                    it('returns the correct Cache headers', done => {
                         expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
                         done();
                     });
@@ -333,7 +338,8 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                 });
 
                 describe('through multiple query parameters (?fields=name&fields=content)', () => {
-                    const test = () => request().get('/libraries/backbone.js/tutorials/what-is-a-view?fields=name&fields=content');
+                    const path = '/libraries/backbone.js/tutorials/what-is-a-view?fields=name&fields=content';
+                    const test = () => request().get(path);
                     let response;
                     before('fetch endpoint', done => {
                         test().end((err, res) => {
@@ -341,8 +347,8 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                             done();
                         });
                     });
-                    it('returns the correct CORS and Cache headers', done => {
-                        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    testCors(path, () => response);
+                    it('returns the correct Cache headers', done => {
                         expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
                         done();
                     });
@@ -375,6 +381,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
+                testCors(path, () => response);
                 it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
                     done();
@@ -410,6 +417,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
+                testCors(path, () => response);
                 it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                     done();
@@ -438,6 +446,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
+                testCors(path, () => response);
                 it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                     done();

--- a/tests/suite/tutorials.js
+++ b/tests/suite/tutorials.js
@@ -13,8 +13,7 @@ describe('/libraries/:library/tutorials', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
                 done();
             });
@@ -50,8 +49,7 @@ describe('/libraries/:library/tutorials', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
                 done();
             });
@@ -89,8 +87,7 @@ describe('/libraries/:library/tutorials', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
                 done();
             });
@@ -127,8 +124,7 @@ describe('/libraries/:library/tutorials', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                 done();
             });
@@ -156,8 +152,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
                     done();
                 });
@@ -188,8 +183,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
                     done();
                 });
@@ -219,8 +213,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
                     done();
                 });
@@ -254,8 +247,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                     done();
                 });
@@ -282,8 +274,7 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
-                it('returns the correct CORS and Cache headers', done => {
-                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                it('returns the correct Cache headers', done => {
                     expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
                     done();
                 });

--- a/tests/suite/update.js
+++ b/tests/suite/update.js
@@ -12,8 +12,7 @@ describe('/update', () => {
             done();
         });
     });
-    it('returns the correct CORS and Cache headers', done => {
-        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+    it('returns the correct Cache headers', done => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=300'); // 5 minutes
         done();
     });

--- a/tests/suite/update.js
+++ b/tests/suite/update.js
@@ -1,9 +1,11 @@
 const { describe, it, before } = require('mocha');
 const { expect } = require('chai');
 const request = require('../base');
+const testCors = require('../cors');
 
 // This endpoint is a prod-only endpoint for monitoring the API auto-update job by maintainers
 describe('/update', () => {
+    const path = '/update';
     const test = () => request().get('/update');
     let response;
     before('fetch endpoint', done => {
@@ -12,6 +14,7 @@ describe('/update', () => {
             done();
         });
     });
+    testCors(path, () => response);
     it('returns the correct Cache headers', done => {
         expect(response).to.have.header('Cache-Control', 'public, max-age=300'); // 5 minutes
         done();

--- a/tests/suite/update.js
+++ b/tests/suite/update.js
@@ -6,7 +6,7 @@ const testCors = require('../cors');
 // This endpoint is a prod-only endpoint for monitoring the API auto-update job by maintainers
 describe('/update', () => {
     const path = '/update';
-    const test = () => request().get('/update');
+    const test = () => request().get(path);
     let response;
     before('fetch endpoint', done => {
         test().end((err, res) => {

--- a/tests/suite/whitelist.js
+++ b/tests/suite/whitelist.js
@@ -12,8 +12,7 @@ describe('/whitelist', () => {
                 done();
             });
         });
-        it('returns the correct CORS and Cache headers', done => {
-            expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+        it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
             done();
         });
@@ -62,8 +61,7 @@ describe('/whitelist', () => {
                 done();
             });
         });
-        it('returns the correct CORS and Cache headers', done => {
-            expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+        it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
             done();
         });
@@ -88,8 +86,7 @@ describe('/whitelist', () => {
                 done();
             });
         });
-        it('returns the correct CORS and Cache headers', done => {
-            expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+        it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
             done();
         });

--- a/tests/suite/whitelist.js
+++ b/tests/suite/whitelist.js
@@ -84,7 +84,8 @@ describe('/whitelist', () => {
 
     describe('Requesting multiple fields', () => {
         describe('through comma-separated string (?fields=extensions,categories)', () => {
-            const test = () => request().get('/whitelist?fields=extensions,categories');
+            const path = '/whitelist?fields=extensions,categories';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -92,8 +93,8 @@ describe('/whitelist', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            testCors(path, ()=> response);
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                 done();
             });
@@ -111,7 +112,8 @@ describe('/whitelist', () => {
         });
 
         describe('through multiple query parameters (?fields=extensions&fields=categories)', () => {
-            const test = () => request().get('/whitelist?fields=extensions&fields=categories');
+            const path = '/whitelist?fields=extensions&fields=categories';
+            const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
                 test().end((err, res) => {
@@ -119,8 +121,8 @@ describe('/whitelist', () => {
                     done();
                 });
             });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+            testCors(path, ()=> response);
+            it('returns the correct Cache headers', done => {
                 expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
                 done();
             });

--- a/tests/suite/whitelist.js
+++ b/tests/suite/whitelist.js
@@ -1,10 +1,12 @@
 const { describe, it, before } = require('mocha');
 const { expect } = require('chai');
 const request = require('../base');
+const testCors = require('../cors');
 
 describe('/whitelist', () => {
     describe('No query params', () => {
-        const test = () => request().get('/whitelist');
+        const path = '/whitelist';
+        const test = () => request().get(path);
         let response;
         before('fetch endpoint', done => {
             test().end((err, res) => {
@@ -12,6 +14,7 @@ describe('/whitelist', () => {
                 done();
             });
         });
+        testCors(path, () => response);
         it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
             done();
@@ -53,7 +56,8 @@ describe('/whitelist', () => {
     });
 
     describe('Requesting a field (?fields=extensions)', () => {
-        const test = () => request().get('/whitelist?fields=extensions');
+        const path = '/whitelist?fields=extensions';
+        const test = () => request().get(path);
         let response;
         before('fetch endpoint', done => {
             test().end((err, res) => {
@@ -61,6 +65,7 @@ describe('/whitelist', () => {
                 done();
             });
         });
+        testCors(path, () => response);
         it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
             done();
@@ -78,7 +83,8 @@ describe('/whitelist', () => {
     });
 
     describe('Requesting all fields (?fields=*)', () => {
-        const test = () => request().get('/whitelist?fields=*');
+        const path = '/whitelist?fields=*';
+        const test = () => request().get(path);
         let response;
         before('fetch endpoint', done => {
             test().end((err, res) => {
@@ -86,6 +92,7 @@ describe('/whitelist', () => {
                 done();
             });
         });
+        testCors(path, () => response);
         it('returns the correct Cache headers', done => {
             expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
             done();

--- a/utils/cors.js
+++ b/utils/cors.js
@@ -5,6 +5,7 @@ const corsOptions = {
     credentials: true,
     methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
     allowedHeaders: ['X-CSRF-Token', 'X-Requested-With', 'Accept', 'Accept-Version', 'Content-Length', 'Content-MD5', 'Content-Type', 'Date', 'X-Api-Version'],
+    optionsSuccessStatus: 204,
 };
 
 module.exports = (app) => app.use(cors(corsOptions));

--- a/utils/cors.js
+++ b/utils/cors.js
@@ -1,0 +1,13 @@
+const cors = require('cors');
+
+const corsOptions = {
+    origin: '*',
+    credentials: true,
+    methods: ['GET', 'PUT', 'POST', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['X-CSRF-Token', 'X-Requested-With', 'Accept', 'Accept-Version', 'Content-Length', 'Content-MD5', 'Content-Type', 'Date', 'X-Api-Version'],
+};
+
+module.exports = (app) => app.use(cors(corsOptions));
+
+// exported for testing
+module.exports.corsOptions = corsOptions;


### PR DESCRIPTION
Currently the custom CORS middleware that the server has doesn't handle `OPTIONS` requests which are used to check the CORS policy of the server.

Got rid of the custom cors middleware and express's official `cors` middleware which handles all the nitty gritty of CORS requests. I made sure I pass all current CORS header values to the `cors` middleware

We use this API at repl.it for people to search for packages and add them to their HTML. All our requests are preflighted making the API unusable for us. We circumvented the issue by removing the content type (json) header, and will probably proxy the API through our servers for extra safety until this is deployed.

Thank you!