### PR TITLE
Make query fields handling robust

### DIFF
--- a/routes/libraries.js
+++ b/routes/libraries.js
@@ -5,6 +5,7 @@ const algoliasearch = require('algoliasearch');
 const cache = require('../utils/cache');
 const filter = require('../utils/filter');
 const respond = require('../utils/respond');
+const queryArray = require('../utils/query_array');
 
 // App constants
 const index = algoliasearch('2QWLVLXZB6', 'e16bd99a5c7a8fccae13ad40762eec3c').initIndex('libraries');
@@ -28,11 +29,11 @@ const algolia = async (query, searchFields) => {
 module.exports = app => {
     app.get('/libraries', async (req, res) => {
         // Get the index results
-        const searchFields = (req.query.search_fields && req.query.search_fields.split(',')) || [];
+        const searchFields = queryArray(req.query, 'search_fields');
         let results;
         try {
             results = await algolia(
-                (req.query.search || '').slice(0, maxQueryLength),
+                (req.query.search || '').toString().slice(0, maxQueryLength),
                 searchFields.includes('*') ? [] : searchFields,
             );
         } catch (err) {
@@ -46,7 +47,7 @@ module.exports = app => {
         }
 
         // Transform the results into our filtered array
-        const requestedFields = (req.query.fields && req.query.fields.split(',')) || [];
+        const requestedFields = queryArray(req.query, 'fields');
         const response = results.map(hit => {
             return filter(
                 {

--- a/routes/library.js
+++ b/routes/library.js
@@ -8,6 +8,7 @@ const tutorials = require('../utils/tutorials');
 const filter = require('../utils/filter');
 const respond = require('../utils/respond');
 const files = require('../utils/files');
+const queryArray = require('../utils/query_array');
 
 // Filter util
 const isWhitelisted = file => {
@@ -59,7 +60,7 @@ module.exports = app => {
         };
 
         // Generate the initial filtered response (without SRI data)
-        const requestedFields = (req.query.fields && req.query.fields.split(',')) || [];
+        const requestedFields = queryArray(req.query, 'fields');
         const response = filter(
             results,
             requestedFields,
@@ -103,7 +104,7 @@ module.exports = app => {
         }
 
         // Generate the initial filtered response (without SRI or tutorials data)
-        const requestedFields = (req.query.fields && req.query.fields.split(',')) || [];
+        const requestedFields = queryArray(req.query, 'fields');
         const response = filter(
             {
                 // Ensure name is first prop

--- a/routes/tutorials.js
+++ b/routes/tutorials.js
@@ -7,6 +7,7 @@ const cache = require('../utils/cache');
 const tutorials = require('../utils/tutorials');
 const filter = require('../utils/filter');
 const respond = require('../utils/respond');
+const queryArray = require('../utils/query_array');
 
 module.exports = app => {
     // Library tutorials
@@ -29,7 +30,7 @@ module.exports = app => {
         const results = tutorials(req.params.library);
 
         // Filter the results
-        const requestedFields = (req.query.fields && req.query.fields.split(',')) || [];
+        const requestedFields = queryArray(req.query, 'fields');
         const response = results.map(data => {
             return filter(
                 data,
@@ -80,7 +81,7 @@ module.exports = app => {
             const modifiedMatch = modified.match(modifiedReg);
 
             // Build the response and filter it
-            const requestedFields = (req.query.fields && req.query.fields.split(',')) || [];
+            const requestedFields = queryArray(req.query, 'fields');
             const response = filter(
                 {
                     id: req.params.tutorial,

--- a/routes/whitelist.js
+++ b/routes/whitelist.js
@@ -3,6 +3,7 @@ const cache = require('../utils/cache');
 const files = require('../utils/files');
 const filter = require('../utils/filter');
 const respond = require('../utils/respond');
+const queryArray = require('../utils/query_array');
 
 module.exports = app => {
     // Whitelist
@@ -14,7 +15,7 @@ module.exports = app => {
         };
 
         // Generate the filtered response
-        const requestedFields = (req.query.fields && req.query.fields.split(',')) || [];
+        const requestedFields = queryArray(req.query, 'fields');
         const response = filter(
             results,
             requestedFields,

--- a/tests/suite/libraries.js
+++ b/tests/suite/libraries.js
@@ -128,6 +128,98 @@ describe('/libraries', function () {
         });
     });
 
+    describe('Requesting multiple fields', () => {
+        describe('through comma-separated string (?fields=filename,version)', () => {
+            const test = () => request().get('/libraries?fields=filename,version');
+            let response;
+            before('fetch endpoint', done => {
+                test().end((err, res) => {
+                    response = res;
+                    done();
+                });
+            });
+            it('returns the correct CORS and Cache headers', done => {
+                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
+                done();
+            });
+            it('returns a JSON body with \'results\', \'total\' and \'available\' properties', done => {
+                expect(response).to.be.json;
+                expect(response.body).to.have.property('results').that.is.an('array');
+                expect(response.body).to.have.property('total').that.is.a('number');
+                expect(response.body).to.have.property('available').that.is.a('number');
+                done();
+            });
+            it('returns all available hits', done => {
+                expect(response.body.results).to.have.lengthOf(response.body.total);
+                expect(response.body.results).to.have.lengthOf(response.body.available);
+                done();
+            });
+            describe('Library object', () => {
+                it('is an object with \'name\', \'latest\' and requested \'filename\' & \'version\' properties', done => {
+                    for (const result of response.body.results) {
+                        expect(result).to.have.property('name');
+                        expect(result).to.have.property('latest');
+                        expect(result).to.have.property('filename');
+                        expect(result).to.have.property('version');
+                    }
+                    done();
+                });
+                it('has no other properties', done => {
+                    for (const result of response.body.results) {
+                        expect(Object.keys(result)).to.have.lengthOf(4);
+                    }
+                    done();
+                });
+            });
+        });
+
+        describe('through multiple query parameters (?fields=filename&fields=version)', () => {
+            const test = () => request().get('/libraries?fields=filename&fields=version');
+            let response;
+            before('fetch endpoint', done => {
+                test().end((err, res) => {
+                    response = res;
+                    done();
+                });
+            });
+            it('returns the correct CORS and Cache headers', done => {
+                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
+                done();
+            });
+            it('returns a JSON body with \'results\', \'total\' and \'available\' properties', done => {
+                expect(response).to.be.json;
+                expect(response.body).to.have.property('results').that.is.an('array');
+                expect(response.body).to.have.property('total').that.is.a('number');
+                expect(response.body).to.have.property('available').that.is.a('number');
+                done();
+            });
+            it('returns all available hits', done => {
+                expect(response.body.results).to.have.lengthOf(response.body.total);
+                expect(response.body.results).to.have.lengthOf(response.body.available);
+                done();
+            });
+            describe('Library object', () => {
+                it('is an object with \'name\', \'latest\' and requested \'filename\' & \'version\' properties', done => {
+                    for (const result of response.body.results) {
+                        expect(result).to.have.property('name');
+                        expect(result).to.have.property('latest');
+                        expect(result).to.have.property('filename');
+                        expect(result).to.have.property('version');
+                    }
+                    done();
+                });
+                it('has no other properties', done => {
+                    for (const result of response.body.results) {
+                        expect(Object.keys(result)).to.have.lengthOf(4);
+                    }
+                    done();
+                });
+            });
+        });
+    });
+
     describe('Requesting all fields (?fields=*)', () => {
         const test = () => request().get('/libraries?fields=*');
         let response;
@@ -275,52 +367,106 @@ describe('/libraries', function () {
         // Testing of the searching functionality should be done by hand
         // TODO: Make this set of tests more robust
 
-        describe('Providing search fields that are valid (?search=backbone.js&search_fields=keywords)', () => {
-            const test = () => request().get('/libraries?search=backbone.js&search_fields=keywords');
-            let response;
-            before('fetch endpoint', done => {
-                test().end((err, res) => {
-                    response = res;
+        describe('Providing search fields that are valid', () => {
+            describe('through comma-separated string (?search=backbone.js&search_fields=keywords,github.user)', () => {
+                const test = () => request().get('/libraries?search=backbone.js&search_fields=keywords,github.user');
+                let response;
+                before('fetch endpoint', done => {
+                    test().end((err, res) => {
+                        response = res;
+                        done();
+                    });
+                });
+                it('returns the correct CORS and Cache headers', done => {
+                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                     done();
                 });
-            });
-            it('returns the correct CORS and Cache headers', done => {
-                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
-                expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
-                done();
-            });
-            it('returns a JSON body with \'results\', \'total\' and \'available\' properties', done => {
-                expect(response).to.be.json;
-                expect(response.body).to.have.property('results').that.is.an('array');
-                expect(response.body).to.have.property('total').that.is.a('number');
-                expect(response.body).to.have.property('available').that.is.a('number');
-                done();
-            });
-            it('returns all available hits', done => {
-                expect(response.body.results).to.have.lengthOf(response.body.total);
-                expect(response.body.results).to.have.lengthOf(response.body.available);
-                done();
-            });
-            describe('Library object', () => {
-                it('is an object with \'name\' and \'latest\' properties', done => {
-                    for (const result of response.body.results) {
-                        expect(result).to.have.property('name').that.is.a('string');
-                        expect(result).to.have.property('latest').that.is.a('string');
-                    }
+                it('returns a JSON body with \'results\', \'total\' and \'available\' properties', done => {
+                    expect(response).to.be.json;
+                    expect(response.body).to.have.property('results').that.is.an('array');
+                    expect(response.body).to.have.property('total').that.is.a('number');
+                    expect(response.body).to.have.property('available').that.is.a('number');
                     done();
                 });
-                // This is fragile! backbone.js doesn't have a keyword for itself so we shouldn't see it
-                it('doesn\'t return the \'backbone.js\' package', done => {
-                    for (const result of response.body.results) {
-                        expect(result.name).to.not.equal('backbone.js');
-                    }
+                it('returns all available hits', done => {
+                    expect(response.body.results).to.have.lengthOf(response.body.total);
+                    expect(response.body.results).to.have.lengthOf(response.body.available);
                     done();
                 });
-                it('has no other properties', done => {
-                    for (const result of response.body.results) {
-                        expect(Object.keys(result)).to.have.lengthOf(2);
-                    }
+                describe('Library object', () => {
+                    it('is an object with \'name\' and \'latest\' properties', done => {
+                        for (const result of response.body.results) {
+                            expect(result).to.have.property('name').that.is.a('string');
+                            expect(result).to.have.property('latest').that.is.a('string');
+                        }
+                        done();
+                    });
+                    // This is fragile!
+                    // backbone.js doesn't have a keyword for itself and is owned by a user so we shouldn't see it
+                    it('doesn\'t return the \'backbone.js\' package', done => {
+                        for (const result of response.body.results) {
+                            expect(result.name).to.not.equal('backbone.js');
+                        }
+                        done();
+                    });
+                    it('has no other properties', done => {
+                        for (const result of response.body.results) {
+                            expect(Object.keys(result)).to.have.lengthOf(2);
+                        }
+                        done();
+                    });
+                });
+            });
+
+            describe('through multiple query parameters (?search=backbone.js&search_fields=keywords&search_fields=github.user)', () => {
+                const test = () => request().get('/libraries?search=backbone.js&search_fields=keywords&search_fields=github.user');
+                let response;
+                before('fetch endpoint', done => {
+                    test().end((err, res) => {
+                        response = res;
+                        done();
+                    });
+                });
+                it('returns the correct CORS and Cache headers', done => {
+                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
                     done();
+                });
+                it('returns a JSON body with \'results\', \'total\' and \'available\' properties', done => {
+                    expect(response).to.be.json;
+                    expect(response.body).to.have.property('results').that.is.an('array');
+                    expect(response.body).to.have.property('total').that.is.a('number');
+                    expect(response.body).to.have.property('available').that.is.a('number');
+                    done();
+                });
+                it('returns all available hits', done => {
+                    expect(response.body.results).to.have.lengthOf(response.body.total);
+                    expect(response.body.results).to.have.lengthOf(response.body.available);
+                    done();
+                });
+                describe('Library object', () => {
+                    it('is an object with \'name\' and \'latest\' properties', done => {
+                        for (const result of response.body.results) {
+                            expect(result).to.have.property('name').that.is.a('string');
+                            expect(result).to.have.property('latest').that.is.a('string');
+                        }
+                        done();
+                    });
+                    // This is fragile!
+                    // backbone.js doesn't have a keyword for itself and is owned by a user so we shouldn't see it
+                    it('doesn\'t return the \'backbone.js\' package', done => {
+                        for (const result of response.body.results) {
+                            expect(result.name).to.not.equal('backbone.js');
+                        }
+                        done();
+                    });
+                    it('has no other properties', done => {
+                        for (const result of response.body.results) {
+                            expect(Object.keys(result)).to.have.lengthOf(2);
+                        }
+                        done();
+                    });
                 });
             });
         });

--- a/tests/suite/library.js
+++ b/tests/suite/library.js
@@ -71,6 +71,72 @@ describe('/libraries/:library/:version', () => {
                 });
             });
 
+            describe('Requesting multiple fields', () => {
+                describe('through comma-separated string (?fields=files,sri)', () => {
+                    const test = () => request().get('/libraries/backbone.js/1.1.0?fields=files,sri');
+                    let response;
+                    before('fetch endpoint', done => {
+                        test().end((err, res) => {
+                            response = res;
+                            done();
+                        });
+                    });
+                    it('returns the correct CORS and Cache headers', done => {
+                        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                        expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
+                        done();
+                    });
+                    it('returns a JSON body that is a library object', done => {
+                        expect(response).to.be.json;
+                        expect(response.body).to.be.an('object');
+                        done();
+                    });
+                    describe('Library version object', () => {
+                        it('is an object with only the \'files\' and \'sri\' properties', done => {
+                            expect(response.body).to.have.property('files').that.is.an('array');
+                            expect(response.body).to.have.property('sri').that.is.an('object');
+                            done();
+                        });
+                        it('has no other properties', done => {
+                            expect(Object.keys(response.body)).to.have.lengthOf(2);
+                            done();
+                        });
+                    });
+                });
+
+                describe('through multiple query parameters (?fields=files&fields=sri)', () => {
+                    const test = () => request().get('/libraries/backbone.js/1.1.0?fields=files&fields=sri');
+                    let response;
+                    before('fetch endpoint', done => {
+                        test().end((err, res) => {
+                            response = res;
+                            done();
+                        });
+                    });
+                    it('returns the correct CORS and Cache headers', done => {
+                        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                        expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
+                        done();
+                    });
+                    it('returns a JSON body that is a library object', done => {
+                        expect(response).to.be.json;
+                        expect(response.body).to.be.an('object');
+                        done();
+                    });
+                    describe('Library version object', () => {
+                        it('is an object with only the \'files\' and \'sri\' properties', done => {
+                            expect(response.body).to.have.property('files').that.is.an('array');
+                            expect(response.body).to.have.property('sri').that.is.an('object');
+                            done();
+                        });
+                        it('has no other properties', done => {
+                            expect(Object.keys(response.body)).to.have.lengthOf(2);
+                            done();
+                        });
+                    });
+                });
+            });
+
             describe('Requesting all fields (?fields=*)', () => {
                 const test = () => request().get('/libraries/backbone.js/1.1.0?fields=*');
                 let response;
@@ -265,7 +331,7 @@ describe('/libraries/:library', () => {
                 expect(response.body).to.be.an('object');
                 done();
             });
-            describe('Library version object', () => {
+            describe('Library object', () => {
                 it('is an object with only the \'assets\' property', done => {
                     expect(response.body).to.have.property('assets').that.is.an('array');
                     done();
@@ -273,6 +339,72 @@ describe('/libraries/:library', () => {
                 it('has no other properties', done => {
                     expect(Object.keys(response.body)).to.have.lengthOf(1);
                     done();
+                });
+            });
+        });
+
+        describe('Requesting multiple fields', () => {
+            describe('through comma-separated string (?fields=name,assets)', () => {
+                const test = () => request().get('/libraries/backbone.js?fields=name,assets');
+                let response;
+                before('fetch endpoint', done => {
+                    test().end((err, res) => {
+                        response = res;
+                        done();
+                    });
+                });
+                it('returns the correct CORS and Cache headers', done => {
+                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
+                    done();
+                });
+                it('returns a JSON body that is a library object', done => {
+                    expect(response).to.be.json;
+                    expect(response.body).to.be.an('object');
+                    done();
+                });
+                describe('Library object', () => {
+                    it('is an object with only the \'name\' and \'assets\' properties', done => {
+                        expect(response.body).to.have.property('name').that.is.a('string');
+                        expect(response.body).to.have.property('assets').that.is.an('array');
+                        done();
+                    });
+                    it('has no other properties', done => {
+                        expect(Object.keys(response.body)).to.have.lengthOf(2);
+                        done();
+                    });
+                });
+            });
+
+            describe('through multiple query parameters (?fields=name&fields=assets)', () => {
+                const test = () => request().get('/libraries/backbone.js?fields=name&fields=assets');
+                let response;
+                before('fetch endpoint', done => {
+                    test().end((err, res) => {
+                        response = res;
+                        done();
+                    });
+                });
+                it('returns the correct CORS and Cache headers', done => {
+                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
+                    done();
+                });
+                it('returns a JSON body that is a library object', done => {
+                    expect(response).to.be.json;
+                    expect(response.body).to.be.an('object');
+                    done();
+                });
+                describe('Library object', () => {
+                    it('is an object with only the \'name\' and \'assets\' properties', done => {
+                        expect(response.body).to.have.property('name').that.is.a('string');
+                        expect(response.body).to.have.property('assets').that.is.an('array');
+                        done();
+                    });
+                    it('has no other properties', done => {
+                        expect(Object.keys(response.body)).to.have.lengthOf(2);
+                        done();
+                    });
                 });
             });
         });

--- a/tests/suite/tutorials.js
+++ b/tests/suite/tutorials.js
@@ -80,6 +80,88 @@ describe('/libraries/:library/tutorials', () => {
             });
         });
 
+        describe('Requesting multiple fields', () => {
+            describe('through comma-separated string (?fields=name,content)', () => {
+                const test = () => request().get('/libraries/backbone.js/tutorials?fields=name,content');
+                let response;
+                before('fetch endpoint', done => {
+                    test().end((err, res) => {
+                        response = res;
+                        done();
+                    });
+                });
+                it('returns the correct CORS and Cache headers', done => {
+                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
+                    done();
+                });
+                it('returns a JSON body that is an array of tutorial objects', done => {
+                    expect(response).to.be.json;
+                    expect(response.body).to.be.an('array');
+                    for (const result of response.body) {
+                        expect(result).to.be.an('object');
+                    }
+                    done();
+                });
+                describe('Tutorial object', () => {
+                    it('is an object with the \'id\', \'name\' and \'content\' properties', done => {
+                        for (const result of response.body) {
+                            expect(result).to.have.property('id').that.is.a('string');
+                            expect(result).to.have.property('name').that.is.a('string');
+                            expect(result).to.have.property('content').that.is.a('string');
+                        }
+                        done();
+                    });
+                    it('has no other properties', done => {
+                        for (const result of response.body) {
+                            expect(Object.keys(result)).to.have.lengthOf(3);
+                        }
+                        done();
+                    });
+                });
+            });
+
+            describe('through multiple query parameters (?fields=name&fields=content)', () => {
+                const test = () => request().get('/libraries/backbone.js/tutorials?fields=name&fields=content');
+                let response;
+                before('fetch endpoint', done => {
+                    test().end((err, res) => {
+                        response = res;
+                        done();
+                    });
+                });
+                it('returns the correct CORS and Cache headers', done => {
+                    expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
+                    done();
+                });
+                it('returns a JSON body that is an array of tutorial objects', done => {
+                    expect(response).to.be.json;
+                    expect(response.body).to.be.an('array');
+                    for (const result of response.body) {
+                        expect(result).to.be.an('object');
+                    }
+                    done();
+                });
+                describe('Tutorial object', () => {
+                    it('is an object with the \'id\', \'name\' and \'content\' properties', done => {
+                        for (const result of response.body) {
+                            expect(result).to.have.property('id').that.is.a('string');
+                            expect(result).to.have.property('name').that.is.a('string');
+                            expect(result).to.have.property('content').that.is.a('string');
+                        }
+                        done();
+                    });
+                    it('has no other properties', done => {
+                        for (const result of response.body) {
+                            expect(Object.keys(result)).to.have.lengthOf(3);
+                        }
+                        done();
+                    });
+                });
+            });
+        });
+
         describe('Requesting all fields (?fields=*)', () => {
             const test = () => request().get('/libraries/backbone.js/tutorials?fields=*');
             let response;
@@ -104,10 +186,12 @@ describe('/libraries/:library/tutorials', () => {
             });
             describe('Tutorial object', () => {
                 // Behaves the same as not including the fields query param
-                it('is an object with \'id\', \'name\' and \'content\' properties', done => {
+                it('is an object with \'id\', \'modified\', \'name\' and \'content\' properties', done => {
                     // and any properties from the tutorial metadata
                     for (const result of response.body) {
                         expect(result).to.have.property('id').that.is.a('string');
+                        expect(result).to.have.property('modified').that.is.a('string');
+                        expect(result.modified).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
                         expect(result).to.have.property('name').that.is.a('string');
                         expect(result).to.have.property('content').that.is.a('string');
                     }
@@ -206,6 +290,72 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                     it('has no other properties', done => {
                         expect(Object.keys(response.body)).to.have.lengthOf(1);
                         done();
+                    });
+                });
+            });
+
+            describe('Requesting multiple fields', () => {
+                describe('through comma-separated string (?fields=name,content)', () => {
+                    const test = () => request().get('/libraries/backbone.js/tutorials/what-is-a-view?fields=name,content');
+                    let response;
+                    before('fetch endpoint', done => {
+                        test().end((err, res) => {
+                            response = res;
+                            done();
+                        });
+                    });
+                    it('returns the correct CORS and Cache headers', done => {
+                        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                        expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
+                        done();
+                    });
+                    it('returns a JSON body that is a tutorial objects', done => {
+                        expect(response).to.be.json;
+                        expect(response.body).to.be.an('object');
+                        done();
+                    });
+                    describe('Tutorial object', () => {
+                        it('is an object with only the \'name\' and \'content\' properties', done => {
+                            expect(response.body).to.have.property('name').that.is.a('string');
+                            expect(response.body).to.have.property('content').that.is.a('string');
+                            done();
+                        });
+                        it('has no other properties', done => {
+                            expect(Object.keys(response.body)).to.have.lengthOf(2);
+                            done();
+                        });
+                    });
+                });
+
+                describe('through multiple query parameters (?fields=name&fields=content)', () => {
+                    const test = () => request().get('/libraries/backbone.js/tutorials/what-is-a-view?fields=name&fields=content');
+                    let response;
+                    before('fetch endpoint', done => {
+                        test().end((err, res) => {
+                            response = res;
+                            done();
+                        });
+                    });
+                    it('returns the correct CORS and Cache headers', done => {
+                        expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                        expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
+                        done();
+                    });
+                    it('returns a JSON body that is a tutorial objects', done => {
+                        expect(response).to.be.json;
+                        expect(response.body).to.be.an('object');
+                        done();
+                    });
+                    describe('Tutorial object', () => {
+                        it('is an object with only the \'name\' and \'content\' properties', done => {
+                            expect(response.body).to.have.property('name').that.is.a('string');
+                            expect(response.body).to.have.property('content').that.is.a('string');
+                            done();
+                        });
+                        it('has no other properties', done => {
+                            expect(Object.keys(response.body)).to.have.lengthOf(2);
+                            done();
+                        });
                     });
                 });
             });

--- a/tests/suite/whitelist.js
+++ b/tests/suite/whitelist.js
@@ -79,6 +79,62 @@ describe('/whitelist', () => {
         });
     });
 
+    describe('Requesting multiple fields', () => {
+        describe('through comma-separated string (?fields=extensions,categories)', () => {
+            const test = () => request().get('/whitelist?fields=extensions,categories');
+            let response;
+            before('fetch endpoint', done => {
+                test().end((err, res) => {
+                    response = res;
+                    done();
+                });
+            });
+            it('returns the correct CORS and Cache headers', done => {
+                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
+                done();
+            });
+            it('returns a JSON body with the \'extensions\' and \'categories\' properties', done => {
+                expect(response).to.be.json;
+                expect(response.body).to.be.an('object');
+                expect(response.body).to.have.property('extensions').that.is.an('array');
+                expect(response.body).to.have.property('categories').that.is.an('object');
+                done();
+            });
+            it('has no other properties', done => {
+                expect(Object.keys(response.body)).to.have.lengthOf(2);
+                done();
+            });
+        });
+
+        describe('through multiple query parameters (?fields=extensions&fields=categories)', () => {
+            const test = () => request().get('/whitelist?fields=extensions&fields=categories');
+            let response;
+            before('fetch endpoint', done => {
+                test().end((err, res) => {
+                    response = res;
+                    done();
+                });
+            });
+            it('returns the correct CORS and Cache headers', done => {
+                expect(response).to.have.header('Access-Control-Allow-Origin', '*');
+                expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
+                done();
+            });
+            it('returns a JSON body with the \'extensions\' and \'categories\' properties', done => {
+                expect(response).to.be.json;
+                expect(response.body).to.be.an('object');
+                expect(response.body).to.have.property('extensions').that.is.an('array');
+                expect(response.body).to.have.property('categories').that.is.an('object');
+                done();
+            });
+            it('has no other properties', done => {
+                expect(Object.keys(response.body)).to.have.lengthOf(2);
+                done();
+            });
+        });
+    });
+
     describe('Requesting all fields (?fields=*)', () => {
         const test = () => request().get('/whitelist?fields=*');
         let response;

--- a/utils/query_array.js
+++ b/utils/query_array.js
@@ -1,0 +1,9 @@
+module.exports = (query, field) => {
+    if (field in query) {
+        if (query[field]) {
+            if (Array.isArray(query[field])) return query[field];
+            return query[field].toString().split(',');
+        }
+    }
+    return [];
+};


### PR DESCRIPTION
Resolves an API error observed through Sentry, where our handling of query parameter fields was failing.

Whilst I'm not certain, I think this is likely because multiple query parameters of the same name were passed, which Express automatically parses as an array. Our logic in the app expected these fields to always be strings, so it failed.

https://sentry.io/share/issue/5257843124d84f1caa81205eb53e7ede/

This PR resolves this by adding logic for when an array is passed from Express.