### PR TITLE
Make packages data updating more robust

### DIFF
--- a/bin/packages.sh
+++ b/bin/packages.sh
@@ -5,6 +5,7 @@ wget -nv -O ./data/packages.temp.min.json https://storage.googleapis.com/cdnjs-a
 
 # Validate that it is a valid libraries JSON file
 node ./bin/valid_json.js ./data/packages.temp.min.json >/dev/null 2>&1 || {
+    rm -f ./data/packages.temp.min.json
     echo "Invalid JSON received, aborting packages data update"
     exit 1
 }

--- a/bin/packages.sh
+++ b/bin/packages.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
-# Get the latest packages data
-rm -f ./data/packages.min.json
-wget -nv -O ./data/packages.min.json https://storage.googleapis.com/cdnjs-assets/package.min.js
+# Get the latest packages data to a temp file
+wget -nv -O ./data/packages.temp.min.json https://storage.googleapis.com/cdnjs-assets/package.min.js
+
+# Validate that it is a valid libraries JSON file
+node ./bin/valid_json.js ./data/packages.temp.min.json >/dev/null 2>&1 || {
+    echo "Invalid JSON received, aborting packages data update"
+    exit 1
+}
+
+# Assuming no error, replace existing packages data
+mv ./data/packages.temp.min.json ./data/packages.min.json

--- a/bin/valid_json.js
+++ b/bin/valid_json.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const isObject = n => Object.prototype.toString.call(n) === '[object Object]';
 
 const main = () => {
-    const [,,file] = process.argv;
+    const [,, file] = process.argv;
     const libraries = JSON.parse(fs.readFileSync(file, 'utf8'));
     assert(isObject(libraries));
     assert('packages' in libraries);

--- a/bin/valid_json.js
+++ b/bin/valid_json.js
@@ -1,9 +1,14 @@
 const fs = require('fs');
+const assert = require('assert');
+
+const isObject = n => Object.prototype.toString.call(n) === '[object Object]';
 
 const main = () => {
     const [,,file] = process.argv;
-    const libraries = JSON.parse(fs.readFileSync(file, 'utf8')).packages;
-    assert(Array.isArray(libraries));
+    const libraries = JSON.parse(fs.readFileSync(file, 'utf8'));
+    assert(isObject(libraries));
+    assert('packages' in libraries);
+    assert(Array.isArray(libraries.packages));
 };
 
 main();

--- a/bin/valid_json.js
+++ b/bin/valid_json.js
@@ -1,0 +1,9 @@
+const fs = require('fs');
+
+const main = () => {
+    const [,,file] = process.argv;
+    const libraries = JSON.parse(fs.readFileSync(file, 'utf8')).packages;
+    assert(Array.isArray(libraries));
+};
+
+main();


### PR DESCRIPTION
## Type of Change

- **Utilities:** Updating logic

## What issue does this relate to?

Mitigation work for https://github.com/cdnjs/cdnjs/issues/13986

### What should this PR do?

When downloading the packages data, first save it to a temp file and validate it with a basic JS script, before replacing the existing JSON data with the newly downloaded data.

### What are the acceptance criteria?

If invalid data is downloaded, the update will abort without changing the existing JSON data locally.

If valid data is downloaded, the local JSON data will be replaced and the API will load the new JSON into memory.