### PR TITLE
Add tutorial created timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ git fetch origin
 git git reset --hard origin/master
 ```
 
-Once this is done, the last modified data log should also be updated, which can be done by running:
+Once this is done, the last modified and created at data logs should also be updated, which can be
+done by running:
 
 ```shell script
-. ./bin/tutorialsModified.sh
+. ./bin/tutorialsTimestamps.sh
 ```
 
 ## Production Deployment
@@ -112,8 +113,9 @@ start the app:
     - Remove the outdated tutorials submodule data
     - Clone the latest tutorials from [cdnjs/tutorials](https://github.com/cdnjs/tutorials)
     - Log the tutorials commit that was cloned
-    - Save the last modified info for the tutorials to
-    [`data/tutorialsModified.txt`](data/tutorialsModified.txt)
+    - Save the last modified and created at info for the tutorials to
+    [`data/tutorialsModified.txt`](data/tutorialsModified.txt) and
+    [`data/tutorialsCreated.txt`](data/tutorialsCreated.txt) respectively
 - Start the API server with GC enabled and additional memory allocated
 
 To change the port that the app binds to, set the `PORT` environment var when running the script.

--- a/bin/initialData.sh
+++ b/bin/initialData.sh
@@ -28,5 +28,5 @@ git clone https://github.com/cdnjs/tutorials.git ./data/tutorials
     git log -n 1 | cat
 )
 
-# Get last modified data for tutorials
-. ./bin/tutorialsModified.sh || exit 1
+# Get last modified/created data for tutorials
+. ./bin/tutorialsTimestamps.sh || exit 1

--- a/bin/packages.sh
+++ b/bin/packages.sh
@@ -4,7 +4,7 @@
 wget -nv -O ./data/packages.temp.min.json https://storage.googleapis.com/cdnjs-assets/package.min.js
 
 # Validate that it is a valid libraries JSON file
-node ./bin/valid_json.js ./data/packages.temp.min.json >/dev/null 2>&1 || {
+node --max-old-space-size=2048 ./bin/valid_json.js ./data/packages.temp.min.json >/dev/null 2>&1 || {
     rm -f ./data/packages.temp.min.json
     echo "Invalid JSON received, aborting packages data update"
     exit 1

--- a/bin/tutorialsTimestamps.sh
+++ b/bin/tutorialsTimestamps.sh
@@ -5,12 +5,15 @@
     # Create empty modified log file
     cd ./data/tutorials
     touch tutorialsModified.txt
+    touch tutorialsCreated.txt
 
-    # Add the modified data for every file in tutorials
+    # Add the modified & created data for every file in tutorials
     git ls-tree -r --name-only HEAD | while read filename; do
         echo "$filename: $(git log -1 --format="%ad" -- $filename)" >> tutorialsModified.txt
+        echo "$filename: $(git log -1 --diff-filter=A --format="%ad" -- $filename)" >> tutorialsCreated.txt
     done
 
-    # Move the log file to the parent data dir
+    # Move the log files to the parent data dir
     mv tutorialsModified.txt ../tutorialsModified.txt
+    mv tutorialsCreated.txt ../tutorialsCreated.txt
 )

--- a/bin/updateData.sh
+++ b/bin/updateData.sh
@@ -27,5 +27,5 @@
     git log -n 1 | cat
 )
 
-# Get last modified data for tutorials
-. ./bin/tutorialsModified.sh || exit 1
+# Get last modified/created data for tutorials
+. ./bin/tutorialsTimestamps.sh || exit 1

--- a/routes/tutorials.js
+++ b/routes/tutorials.js
@@ -1,10 +1,7 @@
-// Library imports
-const fs = require('fs');
-const path = require('path');
-
 // Local imports
 const cache = require('../utils/cache');
 const tutorials = require('../utils/tutorials');
+const tutorial = require('../utils/tutorial');
 const filter = require('../utils/filter');
 const respond = require('../utils/respond');
 const queryArray = require('../utils/query_array');
@@ -70,25 +67,13 @@ module.exports = app => {
 
         // Get the tutorial, if we fail to find it, assume 404
         try {
-            // Get the tutorial meta & content
-            const base = path.join(__dirname, '..', 'data', 'tutorials', req.params.library);
-            const data = JSON.parse(fs.readFileSync(path.join(base, req.params.tutorial, 'tutorial.json'), 'utf8'));
-            const content = fs.readFileSync(path.join(base, req.params.tutorial, 'index.md'), 'utf8');
-
-            // Get the tutorial modified date
-            const modified = fs.readFileSync(path.join(__dirname, '..', 'data', 'tutorialsModified.txt'), 'utf8');
-            const modifiedReg = new RegExp(`(?:^|\n)${path.join(req.params.library, req.params.tutorial, 'tutorial.json')}: (.+)(?:$|\n)`);
-            const modifiedMatch = modified.match(modifiedReg);
+            // Get the tutorial data
+            const data = tutorial(req.params.library, req.params.tutorial);
 
             // Build the response and filter it
             const requestedFields = queryArray(req.query, 'fields');
             const response = filter(
-                {
-                    id: req.params.tutorial,
-                    modified: modifiedMatch && modifiedMatch.length ? new Date(modifiedMatch[1]) : new Date(),
-                    ...data,
-                    content,
-                },
+                data,
                 requestedFields,
                 // If they requested no fields or '*', send them all
                 !requestedFields.length || requestedFields.includes('*'),

--- a/tests/suite/tutorials.js
+++ b/tests/suite/tutorials.js
@@ -29,12 +29,14 @@ describe('/libraries/:library/tutorials', () => {
                 done();
             });
             describe('Tutorial object', () => {
-                it('is an object with \'id\', \'modified\', \'name\' and \'content\' properties', done => {
+                it('is an object with \'id\', \'modified\', \'created\', \'name\' and \'content\' properties', done => {
                     // and any properties from the tutorial metadata
                     for (const result of response.body) {
                         expect(result).to.have.property('id').that.is.a('string');
                         expect(result).to.have.property('modified').that.is.a('string');
                         expect(result.modified).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+                        expect(result).to.have.property('created').that.is.a('string');
+                        expect(result.created).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
                         expect(result).to.have.property('name').that.is.a('string');
                         expect(result).to.have.property('content').that.is.a('string');
                     }
@@ -192,12 +194,14 @@ describe('/libraries/:library/tutorials', () => {
             });
             describe('Tutorial object', () => {
                 // Behaves the same as not including the fields query param
-                it('is an object with \'id\', \'modified\', \'name\' and \'content\' properties', done => {
+                it('is an object with \'id\', \'modified\', \'created\', \'name\' and \'content\' properties', done => {
                     // and any properties from the tutorial metadata
                     for (const result of response.body) {
                         expect(result).to.have.property('id').that.is.a('string');
                         expect(result).to.have.property('modified').that.is.a('string');
                         expect(result.modified).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+                        expect(result).to.have.property('created').that.is.a('string');
+                        expect(result.created).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
                         expect(result).to.have.property('name').that.is.a('string');
                         expect(result).to.have.property('content').that.is.a('string');
                     }
@@ -259,11 +263,13 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                     done();
                 });
                 describe('Tutorial object', () => {
-                    it('is an object with \'id\', \'modified\', \'name\' and \'content\' properties', done => {
+                    it('is an object with \'id\', \'modified\', \'created\', \'name\' and \'content\' properties', done => {
                         // and any properties from the tutorial metadata
                         expect(response.body).to.have.property('id').that.is.a('string');
                         expect(response.body).to.have.property('modified').that.is.a('string');
                         expect(response.body.modified).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+                        expect(response.body).to.have.property('created').that.is.a('string');
+                        expect(response.body.created).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
                         expect(response.body).to.have.property('name').that.is.a('string');
                         expect(response.body).to.have.property('content').that.is.a('string');
                         done();
@@ -393,11 +399,13 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                 });
                 describe('Tutorial object', () => {
                     // Behaves the same as not including the fields query param
-                    it('is an object with \'id\', \'modified\', \'name\' and \'content\' properties', done => {
+                    it('is an object with \'id\', \'modified\', \'created\', \'name\' and \'content\' properties', done => {
                         // and any properties from the tutorial metadata
                         expect(response.body).to.have.property('id').that.is.a('string');
                         expect(response.body).to.have.property('modified').that.is.a('string');
                         expect(response.body.modified).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+                        expect(response.body).to.have.property('created').that.is.a('string');
+                        expect(response.body.created).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
                         expect(response.body).to.have.property('name').that.is.a('string');
                         expect(response.body).to.have.property('content').that.is.a('string');
                         done();

--- a/utils/tutorial.js
+++ b/utils/tutorial.js
@@ -1,0 +1,28 @@
+// Library imports
+const fs = require('fs');
+const path = require('path');
+
+module.exports = (library, tutorial) => {
+    // Fetch modified/created data
+    const modified = fs.readFileSync(path.join(__dirname, '..', 'data', 'tutorialsModified.txt'), 'utf8');
+    const created = fs.readFileSync(path.join(__dirname, '..', 'data', 'tutorialsCreated.txt'), 'utf8');
+
+    // Get the tutorial data
+    const base = path.join(__dirname, '..', 'data', 'tutorials', library, tutorial);
+    const data = JSON.parse(fs.readFileSync(path.join(base, 'tutorial.json'), 'utf8'));
+    const content = fs.readFileSync(path.join(base, 'index.md'), 'utf8');
+
+    // Get the timestamps
+    const timestampReg = new RegExp(`(?:^|\n)${path.join(library, tutorial, 'tutorial.json')}: (.+)(?:$|\n)`);
+    const modifiedMatch = modified.match(timestampReg);
+    const createdMatch = created.match(timestampReg);
+
+    // Generate the data
+    return {
+        id: tutorial,
+        modified: modifiedMatch && modifiedMatch.length ? new Date(modifiedMatch[1]) : new Date(),
+        created: createdMatch && createdMatch.length ? new Date(createdMatch[1]) : new Date(),
+        ...data,
+        content,
+    };
+};

--- a/utils/tutorials.js
+++ b/utils/tutorials.js
@@ -2,6 +2,9 @@
 const fs = require('fs');
 const path = require('path');
 
+// Local imports
+const tutorial = require('./tutorial');
+
 module.exports = library => {
     // Base tutorials path
     const base = path.join(__dirname, '..', 'data', 'tutorials', library);
@@ -14,23 +17,10 @@ module.exports = library => {
         // If no tutorials, this will error and results will be an empty array
     }
 
-    // Fetch modified data
-    const modified = fs.readFileSync(path.join(__dirname, '..', 'data', 'tutorialsModified.txt'), 'utf8');
-
     // Get the data & contents of each one, and as a dictionary.
     return results.map(file => {
         try {
-            const data = JSON.parse(fs.readFileSync(path.join(base, file, 'tutorial.json'), 'utf8'));
-            const content = fs.readFileSync(path.join(base, file, 'index.md'), 'utf8');
-            const modifiedReg = new RegExp(`(?:^|\n)${path.join(library, file, 'tutorial.json')}: (.+)(?:$|\n)`);
-            const modifiedMatch = modified.match(modifiedReg);
-
-            return {
-                id: file,
-                modified: modifiedMatch && modifiedMatch.length ? new Date(modifiedMatch[1]) : new Date(),
-                ...data,
-                content,
-            };
+            return tutorial(library, file);
         } catch (_) {
             // If index.md or tutorial.json don't exist (or not valid), just skip this result
         }


### PR DESCRIPTION
## Type of Change

- **Routes:** Tutorial & tutorials
- **Utilities:** Tutorial & tutorials
- **Tests:** Tutorial & tutorials
- **Something else:** Bin scripts, tutorial timestamps

## What issue does this relate to?

N/A

### What should this PR do?

Updates the timestamp generation logic for tutorials to include the initial commit timestamp as well as the current last modified timestamp. Also centralises the logic used for loading tutorial data into the app and adds in the created at timestamp.

### What are the acceptance criteria?

- Fetching all tutorials for a library includes the created at timestamp for each one.
- Fetching an individual tutorial includes the created at timestamp.
- The initial data & update data scripts both correctly generated both the modified & created at tutorial timestamp log files.