### PR TITLE
Validate SRI files

### DIFF
--- a/routes/library.js
+++ b/routes/library.js
@@ -1,5 +1,4 @@
 // Library imports
-const fs = require('fs');
 const path = require('path');
 
 // Local imports
@@ -9,6 +8,7 @@ const filter = require('../utils/filter');
 const respond = require('../utils/respond');
 const files = require('../utils/files');
 const queryArray = require('../utils/query_array');
+const sriForVersion = require('../utils/sri_for_version');
 
 // Filter util
 const isWhitelisted = file => {
@@ -71,7 +71,7 @@ module.exports = app => {
         // Load SRI data if needed
         if ('sri' in response) {
             try {
-                response.sri = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'sri', req.params.library, `${version.version}.json`), 'utf8'));
+                response.sri = sriForVersion(req.params.library, version.version, version.rawFiles);
             } catch (_) {
                 // If we can't load, set SRI to a blank object
                 response.sri = {};
@@ -135,7 +135,7 @@ module.exports = app => {
         // Load SRI for latest if needed
         if ('sri' in response) {
             try {
-                response.sri = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'sri', req.params.library, `${lib.version}.json`), 'utf8'))[lib.filename];
+                response.sri = sriForVersion(req.params.library, lib.version, [lib.filename])[lib.filename];
             } catch (_) {
                 // If we fail to load, leave it as null
             }
@@ -148,7 +148,7 @@ module.exports = app => {
                 asset.files = asset.files.filter(isWhitelisted);
 
                 try {
-                    asset.sri = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'sri', req.params.library, `${asset.version}.json`), 'utf8'));
+                    asset.sri = sriForVersion(req.params.library, asset.version, asset.rawFiles);
                 } catch (_) {
                     // If we can't load, set SRI to a blank object
                     asset.sri = {};

--- a/utils/sri_for_version.js
+++ b/utils/sri_for_version.js
@@ -1,0 +1,44 @@
+// Library imports
+const Sentry = require('@sentry/node');
+
+module.exports = (library, version, files) => {
+    // Load in the data for the version, if it doesn't exist, error
+    let data;
+    try {
+        data = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'data', 'sri', library, `${version}.json`), 'utf8'));
+    } catch (e) {
+        const fullLibrary = `${library}/${version}`;
+        console.warn('Failed to load SRI data for', fullLibrary);
+        console.info(e, e.message, e.stack);
+        Sentry.captureException({
+            name: 'Failed to load SRI data',
+            message: `${fullLibrary}: ${e.message}`,
+        });
+        throw e;
+    }
+
+    // Build the SRI object
+    const sri = {};
+    for (const file in files) {
+        if (!Object.prototype.hasOwnProperty.call(files, file)) continue;
+
+        // If we have an SRI entry for this, add it
+        if (file in data) {
+            sri[file] = data[file];
+            continue;
+        }
+
+        // If we don't have an SRI entry, but expect one, error!
+        if (file.endsWith('.js') || file.endsWith('.css')) {
+            const fullFile = `${library}/${version}/${file}`;
+            console.warn('Missing SRI entry for', fullFile);
+            Sentry.captureException({
+                name: 'Missing SRI entry',
+                message: fullFile,
+            });
+        }
+    }
+
+    // Done
+    return sri;
+};

--- a/utils/sri_for_version.js
+++ b/utils/sri_for_version.js
@@ -1,4 +1,6 @@
 // Library imports
+const fs = require('fs');
+const path = require('path');
 const Sentry = require('@sentry/node');
 
 module.exports = (library, version, files) => {
@@ -19,9 +21,7 @@ module.exports = (library, version, files) => {
 
     // Build the SRI object
     const sri = {};
-    for (const file in files) {
-        if (!Object.prototype.hasOwnProperty.call(files, file)) continue;
-
+    for (const file of files) {
         // If we have an SRI entry for this, add it
         if (file in data) {
             sri[file] = data[file];


### PR DESCRIPTION
## Type of Change

- **Routes:** Library & library version
- **Utilities:** SRI for version

## What issue does this relate to?

N/A

### What should this PR do?

As discussed on Slack, we currently have no easy way of knowing if SRI data is missing for files. This adds logic to our SRI loading, so that if SRI data is missing for js/css files when a request comes in for a library or a version of a libary, we will log an error in Sentry & console.

This doesn't make the request fail, the existing clean error handling will allow SRI to be blank etc, but it does mean we will see Sentry errors for any missing SRI data.

### What are the acceptance criteria?

CI passes, logic looks correct.