### PR TITLE
Disallow indexing

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@ const Sentry = require('@sentry/node');
 const morgan = require('morgan');
 
 // Local imports
-const cache = require('./utils/cache');
 const cors = require('./utils/cors');
 const updateLoad = require('./update/load');
 const updateJob = require('./update/job');
@@ -21,6 +20,7 @@ const libraryRoutes = require('./routes/library');
 const whitelistRoutes = require('./routes/whitelist');
 const statsRoutes = require('./routes/stats');
 const updateRoutes = require('./routes/update');
+const indexRoutes = require('./routes/index');
 const testingRoutes = require('./routes/testing');
 
 // App constants
@@ -81,17 +81,8 @@ module.exports = async () => {
     whitelistRoutes(app);
     statsRoutes(app);
     updateRoutes(app);
+    indexRoutes(app);
     if (localMode) testingRoutes(app);
-
-    // Redirect root the API docs
-    app.get('/', (req, res) => {
-        // Set a 355 day (same as CDN) life on this response
-        // This is also immutable
-        cache(res, 355 * 24 * 60 * 60, true);
-
-        // Redirect to the API docs
-        res.redirect(301, 'https://cdnjs.com/api');
-    });
 
     // Catch-all errors
     if (process.env.SENTRY_DSN) app.use(Sentry.Handlers.errorHandler());

--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -6,7 +6,7 @@ const notFound = require('../utils/not_found');
 
 module.exports = {
     notFound: (req, res, next) => {
-        notFound(res, 'Endpoint');
+        notFound(req, res, 'Endpoint');
         next();
     },
     error: (err, req, res, next) => {

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,25 @@
+// Local imports
+const cache = require('../utils/cache');
+
+module.exports = app => {
+    // Redirect root the API docs
+    app.get('/', (req, res) => {
+        // Set a 355 day (same as CDN) life on this response
+        // This is also immutable
+        cache(res, 355 * 24 * 60 * 60, true);
+
+        // Redirect to the API docs
+        res.redirect(301, 'https://cdnjs.com/api');
+    });
+
+    // Don't ever index anything on the API
+    app.get('/robots.txt', (req, res) => {
+        // Set a 355 day (same as CDN) life on this response
+        // This is also immutable
+        cache(res, 355 * 24 * 60 * 60, true);
+
+        // Disallow all robots
+        res.type('text/plain');
+        res.send('User-agent: *\nDisallow: /');
+    });
+};

--- a/routes/library.js
+++ b/routes/library.js
@@ -29,6 +29,7 @@ module.exports = app => {
             const lib = await kvCleanFetch(
                 kvLibrary,
                 [ req.params.library ],
+                req,
                 res,
                 next,
                 'Library',
@@ -39,6 +40,7 @@ module.exports = app => {
             const version = await kvCleanFetch(
                 kvLibraryVersion,
                 [ lib.name, req.params.version ],
+                req,
                 res,
                 next,
                 'Version',
@@ -95,6 +97,7 @@ module.exports = app => {
             const lib = await kvCleanFetch(
                 kvFullLibrary,
                 [ req.params.library ],
+                req,
                 res,
                 next,
                 'Library',

--- a/routes/tutorials.js
+++ b/routes/tutorials.js
@@ -16,6 +16,7 @@ module.exports = app => {
             const lib = await kvCleanFetch(
                 kvLibrary,
                 [ req.params.library ],
+                req,
                 res,
                 next,
                 'Library',
@@ -58,6 +59,7 @@ module.exports = app => {
             const lib = await kvCleanFetch(
                 kvLibrary,
                 [ req.params.library ],
+                req,
                 res,
                 next,
                 'Library',
@@ -84,7 +86,7 @@ module.exports = app => {
                 // Send the response
                 respond(req, res, response);
             } catch (_) {
-                notFound(res, 'Tutorial');
+                notFound(req, res, 'Tutorial');
             }
         } catch (err) {
             next(err);

--- a/tests/human.js
+++ b/tests/human.js
@@ -1,0 +1,22 @@
+const { it } = require('mocha');
+const { expect } = require('chai');
+
+const testHuman = getResponse => {
+    it('returns the no-index header', done => {
+        const response = getResponse();
+        expect(response).to.have.header('X-Robots-Tag', 'noindex');
+        done();
+    });
+    it('returns a HTML body', done => {
+        const response = getResponse();
+        expect(response).to.be.html;
+        done();
+    });
+    it('returns the no-index meta tag', done => {
+        const response = getResponse();
+        expect(response.text).to.match(/<meta\s+name=["']robots["']\s+content=["']noindex["']\s*\/?>/);
+        done();
+    });
+};
+
+module.exports = testHuman;

--- a/tests/suite/index.js
+++ b/tests/suite/index.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 const request = require('../base');
 const fetch = require('../fetch');
 const testCors = require('../cors');
+const testHuman = require('../human');
 
 describe('/', () => {
     const path = '/';
@@ -26,8 +27,8 @@ describe('/', () => {
     });
 });
 
-describe('/this-route-doesnt-exist', () => {
-    const path = '/this-route-doesnt-exist';
+describe('/robots.txt', () => {
+    const path = '/robots.txt';
     const test = () => request().get(path);
     let response;
     before('fetch endpoint', done => {
@@ -38,15 +39,57 @@ describe('/this-route-doesnt-exist', () => {
     });
     testCors(path, () => response);
     it('returns the correct Cache headers', done => {
-        expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
+        expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
         done();
     });
-    it('returns a JSON body that is a valid error response', done => {
-        expect(response).to.be.json;
-        expect(response.body).to.be.an('object');
-        expect(response.body).to.have.property('error', true);
-        expect(response.body).to.have.property('status', 404);
-        expect(response.body).to.have.property('message', 'Endpoint not found');
+    it('disallows all indexing', done => {
+        expect(response).to.be.text;
+        expect(response.text).to.eq('User-agent: *\nDisallow: /');
         done();
+    });
+});
+
+describe('/this-route-doesnt-exist', () => {
+    describe('No query params', () => {
+        const path = '/this-route-doesnt-exist';
+        const test = () => request().get(path);
+        let response;
+        before('fetch endpoint', done => {
+            fetch(test).then(res => {
+                response = res;
+                done();
+            });
+        });
+        testCors(path, () => response);
+        it('returns the correct Cache headers', done => {
+            expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
+            done();
+        });
+        it('returns a JSON body that is a valid error response', done => {
+            expect(response).to.be.json;
+            expect(response.body).to.be.an('object');
+            expect(response.body).to.have.property('error', true);
+            expect(response.body).to.have.property('status', 404);
+            expect(response.body).to.have.property('message', 'Endpoint not found');
+            done();
+        });
+    });
+
+    describe('Requesting human response (?output=human)', () => {
+        const path = '/this-route-doesnt-exist?output=human';
+        const test = () => request().get(path);
+        let response;
+        before('fetch endpoint', done => {
+            fetch(test, 5000).then(res => {
+                response = res;
+                done();
+            });
+        });
+        testCors(path, () => response);
+        it('returns the correct Cache headers', done => {
+            expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
+            done();
+        });
+        testHuman(() => response);
     });
 });

--- a/tests/suite/libraries.js
+++ b/tests/suite/libraries.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 const request = require('../base');
 const fetch = require('../fetch');
 const testCors = require('../cors');
+const testHuman = require('../human');
 
 describe('/libraries', () => {
     describe('No query params', () => {
@@ -61,6 +62,24 @@ describe('/libraries', () => {
                 done();
             });
         });
+    });
+
+    describe('Requesting human response (?output=human)', () => {
+        const path = '/libraries?output=human';
+        const test = () => request().get(path);
+        let response;
+        before('fetch endpoint', done => {
+            fetch(test, 5000).then(res => {
+                response = res;
+                done();
+            });
+        });
+        testCors(path, () => response);
+        it('returns the correct Cache headers', done => {
+            expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
+            done();
+        });
+        testHuman(() => response);
     });
 
     describe('Limiting number of results (?limit=10)', () => {

--- a/tests/suite/library.js
+++ b/tests/suite/library.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 const request = require('../base');
 const fetch = require('../fetch');
 const testCors = require('../cors');
+const testHuman = require('../human');
 
 describe('/libraries/:library/:version', () => {
     describe('Requesting a valid library (:library = backbone.js)', () => {
@@ -41,6 +42,24 @@ describe('/libraries/:library/:version', () => {
                         done();
                     });
                 });
+            });
+
+            describe('Requesting human response (?output=human)', () => {
+                const path = '/libraries/backbone.js/1.1.0?output=human';
+                const test = () => request().get(path);
+                let response;
+                before('fetch endpoint', done => {
+                    fetch(test, 5000).then(res => {
+                        response = res;
+                        done();
+                    });
+                });
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=30672000, immutable'); // 355 days
+                    done();
+                });
+                testHuman(() => response);
             });
 
             describe('Requesting a field (?fields=files)', () => {
@@ -205,12 +224,30 @@ describe('/libraries/:library/:version', () => {
                     done();
                 });
             });
+
+            describe('Requesting human response (?output=human)', () => {
+                const path = '/libraries/backbone.js/this-version-doesnt-exist?output=human';
+                const test = () => request().get(path);
+                let response;
+                before('fetch endpoint', done => {
+                    fetch(test, 5000).then(res => {
+                        response = res;
+                        done();
+                    });
+                });
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
+                    done();
+                });
+                testHuman(() => response);
+            });
         });
     });
 
-    describe('Requesting a non-existent library (:library = this-library-doesnt-exist)', () => {
+    describe('Requesting a non-existent library (:library = this-library-doesnt-exist, :version = this-version-doesnt-exist)', () => {
         describe('No query params', () => {
-            const path = '/libraries/this-library-doesnt-exist';
+            const path = '/libraries/this-library-doesnt-exist/this-version-doesnt-exist';
             const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
@@ -232,6 +269,24 @@ describe('/libraries/:library/:version', () => {
                 expect(response.body).to.have.property('message', 'Library not found');
                 done();
             });
+        });
+
+        describe('Requesting human response (?output=human)', () => {
+            const path = '/libraries/this-library-doesnt-exist/this-version-doesnt-exist?output=human';
+            const test = () => request().get(path);
+            let response;
+            before('fetch endpoint', done => {
+                fetch(test, 5000).then(res => {
+                    response = res;
+                    done();
+                });
+            });
+            testCors(path, () => response);
+            it('returns the correct Cache headers', done => {
+                expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
+                done();
+            });
+            testHuman(() => response);
         });
     });
 });
@@ -320,6 +375,24 @@ describe('/libraries/:library', () => {
                     });
                 });
             });
+        });
+
+        describe('Requesting human response (?output=human)', () => {
+            const path = '/libraries/backbone.js?output=human';
+            const test = () => request().get(path);
+            let response;
+            before('fetch endpoint', done => {
+                fetch(test, 5000).then(res => {
+                    response = res;
+                    done();
+                });
+            });
+            testCors(path, () => response);
+            it('returns the correct Cache headers', done => {
+                expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
+                done();
+            });
+            testHuman(() => response);
         });
 
         describe('Requesting a field (?fields=assets)', () => {
@@ -490,6 +563,24 @@ describe('/libraries/:library', () => {
                 expect(response.body).to.have.property('message', 'Library not found');
                 done();
             });
+        });
+
+        describe('Requesting human response (?output=human)', () => {
+            const path = '/libraries/this-library-doesnt-exist?output=human';
+            const test = () => request().get(path);
+            let response;
+            before('fetch endpoint', done => {
+                fetch(test, 5000).then(res => {
+                    response = res;
+                    done();
+                });
+            });
+            testCors(path, () => response);
+            it('returns the correct Cache headers', done => {
+                expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
+                done();
+            });
+            testHuman(() => response);
         });
     });
 });

--- a/tests/suite/stats.js
+++ b/tests/suite/stats.js
@@ -3,35 +3,56 @@ const { expect } = require('chai');
 const request = require('../base');
 const fetch = require('../fetch');
 const testCors = require('../cors');
+const testHuman = require('../human');
 
 describe('/stats', () => {
-    const path = '/stats';
-    const test = () => request().get(path);
-    let response;
-    before('fetch endpoint', done => {
-        fetch(test).then(res => {
-            response = res;
+    describe('No query params', () => {
+        const path = '/stats';
+        const test = () => request().get(path);
+        let response;
+        before('fetch endpoint', done => {
+            fetch(test).then(res => {
+                response = res;
+                done();
+            });
+        });
+        testCors(path, () => response);
+        it('returns the correct Cache headers', done => {
+            expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
             done();
         });
-    });
-    testCors(path, () => response);
-    it('returns the correct Cache headers', done => {
-        expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
-        done();
-    });
-    it('returns a JSON body that is a stats object', done => {
-        expect(response).to.be.json;
-        expect(response.body).to.be.an('object');
-        done();
-    });
-    describe('cdnjs stats object', () => {
-        it('is an object with the \'libraries\' property', done => {
-            expect(response.body).to.have.property('libraries').that.is.an('number');
+        it('returns a JSON body that is a stats object', done => {
+            expect(response).to.be.json;
+            expect(response.body).to.be.an('object');
             done();
         });
-        it('has no other properties', done => {
-            expect(Object.keys(response.body)).to.have.lengthOf(1);
+        describe('cdnjs stats object', () => {
+            it('is an object with the \'libraries\' property', done => {
+                expect(response.body).to.have.property('libraries').that.is.an('number');
+                done();
+            });
+            it('has no other properties', done => {
+                expect(Object.keys(response.body)).to.have.lengthOf(1);
+                done();
+            });
+        });
+    });
+
+    describe('Requesting human response (?output=human)', () => {
+        const path = '/stats?output=human';
+        const test = () => request().get(path);
+        let response;
+        before('fetch endpoint', done => {
+            fetch(test, 5000).then(res => {
+                response = res;
+                done();
+            });
+        });
+        testCors(path, () => response);
+        it('returns the correct Cache headers', done => {
+            expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
             done();
         });
+        testHuman(() => response);
     });
 });

--- a/tests/suite/tutorials.js
+++ b/tests/suite/tutorials.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 const request = require('../base');
 const fetch = require('../fetch');
 const testCors = require('../cors');
+const testHuman = require('../human');
 
 describe('/libraries/:library/tutorials', () => {
     describe('Requesting for a valid library (:library = backbone.js)', () => {
@@ -44,6 +45,24 @@ describe('/libraries/:library/tutorials', () => {
                     done();
                 });
             });
+        });
+
+        describe('Requesting human response (?output=human)', () => {
+            const path = '/libraries/backbone.js/tutorials?output=human';
+            const test = () => request().get(path);
+            let response;
+            before('fetch endpoint', done => {
+                fetch(test, 5000).then(res => {
+                    response = res;
+                    done();
+                });
+            });
+            testCors(path, () => response);
+            it('returns the correct Cache headers', done => {
+                expect(response).to.have.header('Cache-Control', 'public, max-age=86400'); // 24 hours
+                done();
+            });
+            testHuman(() => response);
         });
 
         describe('Requesting a field (?fields=name)', () => {
@@ -237,6 +256,24 @@ describe('/libraries/:library/tutorials', () => {
                 done();
             });
         });
+
+        describe('Requesting human response (?output=human)', () => {
+            const path = '/libraries/this-library-doesnt-exist/tutorials?output=human';
+            const test = () => request().get(path);
+            let response;
+            before('fetch endpoint', done => {
+                fetch(test, 5000).then(res => {
+                    response = res;
+                    done();
+                });
+            });
+            testCors(path, () => response);
+            it('returns the correct Cache headers', done => {
+                expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
+                done();
+            });
+            testHuman(() => response);
+        });
     });
 });
 
@@ -276,6 +313,24 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                         done();
                     });
                 });
+            });
+
+            describe('Requesting human response (?output=human)', () => {
+                const path = '/libraries/backbone.js/tutorials/what-is-a-view?output=human';
+                const test = () => request().get(path);
+                let response;
+                before('fetch endpoint', done => {
+                    fetch(test, 5000).then(res => {
+                        response = res;
+                        done();
+                    });
+                });
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=1209600'); // 2 weeks
+                    done();
+                });
+                testHuman(() => response);
             });
 
             describe('Requesting a field (?fields=name)', () => {
@@ -440,6 +495,24 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                     done();
                 });
             });
+
+            describe('Requesting human response (?output=human)', () => {
+                const path = '/libraries/backbone.js/tutorials/this-tutorial-doesnt-exist?output=human';
+                const test = () => request().get(path);
+                let response;
+                before('fetch endpoint', done => {
+                    fetch(test, 5000).then(res => {
+                        response = res;
+                        done();
+                    });
+                });
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
+                    done();
+                });
+                testHuman(() => response);
+            });
         });
     });
 
@@ -468,6 +541,24 @@ describe('/libraries/:library/tutorials/:tutorial', () => {
                     expect(response.body).to.have.property('message', 'Library not found');
                     done();
                 });
+            });
+
+            describe('Requesting human response (?output=human)', () => {
+                const path = '/libraries/this-library-doesnt-exist/tutorials/this-tutorial-doesnt-exist?output=human';
+                const test = () => request().get(path);
+                let response;
+                before('fetch endpoint', done => {
+                    fetch(test, 5000).then(res => {
+                        response = res;
+                        done();
+                    });
+                });
+                testCors(path, () => response);
+                it('returns the correct Cache headers', done => {
+                    expect(response).to.have.header('Cache-Control', 'public, max-age=3600'); // 1 hour
+                    done();
+                });
+                testHuman(() => response);
             });
         });
     });

--- a/tests/suite/update.js
+++ b/tests/suite/update.js
@@ -3,26 +3,47 @@ const { expect } = require('chai');
 const request = require('../base');
 const fetch = require('../fetch');
 const testCors = require('../cors');
+const testHuman = require('../human');
 
 // This endpoint is a prod-only endpoint for monitoring the API auto-update job by maintainers
 describe('/update', () => {
-    const path = '/update';
-    const test = () => request().get(path);
-    let response;
-    before('fetch endpoint', done => {
-        fetch(test).then(res => {
-            response = res;
+    describe('No query params', () => {
+        const path = '/update';
+        const test = () => request().get(path);
+        let response;
+        before('fetch endpoint', done => {
+            fetch(test).then(res => {
+                response = res;
+                done();
+            });
+        });
+        testCors(path, () => response);
+        it('returns the correct Cache headers', done => {
+            expect(response).to.have.header('Cache-Control', 'public, max-age=300'); // 5 minutes
+            done();
+        });
+        it('returns a JSON body', done => {
+            expect(response).to.be.json;
+            expect(response.body).to.be.an('object');
             done();
         });
     });
-    testCors(path, () => response);
-    it('returns the correct Cache headers', done => {
-        expect(response).to.have.header('Cache-Control', 'public, max-age=300'); // 5 minutes
-        done();
-    });
-    it('returns a JSON body', done => {
-        expect(response).to.be.json;
-        expect(response.body).to.be.an('object');
-        done();
+
+    describe('Requesting human response (?output=human)', () => {
+        const path = '/update?output=human';
+        const test = () => request().get(path);
+        let response;
+        before('fetch endpoint', done => {
+            fetch(test, 5000).then(res => {
+                response = res;
+                done();
+            });
+        });
+        testCors(path, () => response);
+        it('returns the correct Cache headers', done => {
+            expect(response).to.have.header('Cache-Control', 'public, max-age=300'); // 5 minutes
+            done();
+        });
+        testHuman(() => response);
     });
 });

--- a/tests/suite/whitelist.js
+++ b/tests/suite/whitelist.js
@@ -3,6 +3,7 @@ const { expect } = require('chai');
 const request = require('../base');
 const fetch = require('../fetch');
 const testCors = require('../cors');
+const testHuman = require('../human');
 
 describe('/whitelist', () => {
     describe('No query params', () => {
@@ -54,6 +55,24 @@ describe('/whitelist', () => {
                 done();
             });
         });
+    });
+
+    describe('Requesting human response (?output=human)', () => {
+        const path = '/whitelist?output=human';
+        const test = () => request().get(path);
+        let response;
+        before('fetch endpoint', done => {
+            fetch(test, 5000).then(res => {
+                response = res;
+                done();
+            });
+        });
+        testCors(path, () => response);
+        it('returns the correct Cache headers', done => {
+            expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // 6 hours
+            done();
+        });
+        testHuman(() => response);
     });
 
     describe('Requesting a field (?fields=extensions)', () => {

--- a/utils/libraries.js
+++ b/utils/libraries.js
@@ -208,13 +208,13 @@ const kvLibrarySri = async library => {
 };
 
 // Fetch data from a KV endpoint cleanly, handling 404 and error responses for Express
-const kvCleanFetch = async (method, parameters, response, errorCallback, notFoundMessage) => {
+const kvCleanFetch = async (method, parameters, request, response, errorCallback, notFoundMessage) => {
     let data;
     try {
         data = await method(...parameters);
     } catch (err) {
         if (err.status === 404) {
-            notFound(response, notFoundMessage);
+            notFound(request, response, notFoundMessage);
             return;
         }
 

--- a/utils/not_found.js
+++ b/utils/not_found.js
@@ -1,12 +1,14 @@
 // Local imports
 const cache = require('./cache');
+const respond = require('./respond');
 
-module.exports = (res, item) => {
+module.exports = (req, res, item) => {
     // Set a 1 hour on this response
     cache(res, 60 * 60);
 
     // Send the error response
-    res.status(404).json({
+    res.status(404);
+    respond(req, res, {
         error: true,
         status: 404,
         message: `${item} not found`,

--- a/utils/respond.js
+++ b/utils/respond.js
@@ -1,7 +1,8 @@
 const human = (res, data) => {
     res.header('Content-Type', 'text/html');
+    res.header('X-Robots-Tag', 'noindex');
     res.send('<!doctype><html>' +
-        '<head><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css" integrity="sha256-Zd1icfZ72UBmsId/mUcagrmN7IN5Qkrvh75ICHIQVTk=" crossorigin="anonymous"/></head><body>' +
+        '<head><meta name="robots" content="noindex"/><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css" integrity="sha256-Zd1icfZ72UBmsId/mUcagrmN7IN5Qkrvh75ICHIQVTk=" crossorigin="anonymous"/></head><body>' +
         '<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" integrity="sha256-/BfiIkHlHoVihZdc6TFuj7MmJ0TWcWsMXkeDFwhi0zw=" crossorigin="anonymous"></script>' +
         '<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/languages/json.min.js" integrity="sha256-KPdGtw3AdDen/v6+9ue/V3m+9C2lpNiuirroLsHrJZM=" crossorigin="anonymous" defer></script>' +
         '<script src="https://cdnjs.cloudflare.com/ajax/libs/json2/20160511/json2.min.js" integrity="sha256-Fsw5X9ZUnlJb302irkG8pKCRwerGfxSArAw22uG/QkQ=" crossorigin="anonymous"></script>' +


### PR DESCRIPTION
## Type of Change

- **Routes:** Added /robots.txt, moved / to own file
- **Utilities:** Responses now include no-index
- **Tests:** Test all human responses for no-index

## What issue does this relate to?

N/A

### What should this PR do?

Ensure that we are doing everything we can to stop Google etc. randomly indexing some responses from the API and showing them in search results.

### What are the acceptance criteria?

All specs pass, no-index makes sense.