### PR TITLE
Use twitter-bootstrap instead of hi-sven for test

### DIFF
--- a/tests/suite/libraries.js
+++ b/tests/suite/libraries.js
@@ -328,8 +328,8 @@ describe('/libraries', () => {
         // Testing of the searching functionality should be done by hand
         // TODO: Make this set of tests more robust
 
-        describe('Providing a short query (?search=hi-sven)', () => {
-            const path = '/libraries?search=hi-sven';
+        describe('Providing a short query (?search=twitter-bootstrap)', () => {
+            const path = '/libraries?search=twitter-bootstrap';
             const test = () => request().get(path);
             let response;
             before('fetch endpoint', done => {
@@ -356,8 +356,8 @@ describe('/libraries', () => {
                 done();
             });
             describe('Library object', () => {
-                it('returns the \'hi-sven\' package as the first object', done => {
-                    expect(response.body.results[0]).to.have.property('name', 'hi-sven');
+                it('returns the \'twitter-bootstrap\' package as the first object', done => {
+                    expect(response.body.results[0]).to.have.property('name', 'twitter-bootstrap');
                     done();
                 });
                 it('is an object with \'name\' and \'latest\' properties', done => {


### PR DESCRIPTION
## Type of Change

- **Tests:** Failing fragile Algolia test

## What issue does this relate to?

N/A

### What should this PR do?

Changes the search query being used for one of the Aloglia tests, as the previous one no longer returns the result expected by the test (still functioning as expected though!)

### What are the acceptance criteria?

Test suite passes.