### PR TITLE
Allow setting metadata base URL from env var

### DIFF
--- a/utils/libraries.js
+++ b/utils/libraries.js
@@ -7,7 +7,7 @@ const gunzip = require('gunzip-maybe');
 const notFound = require('./not_found');
 
 // Globals
-const kvBase = 'https://metadata.speedcdnjs.com';
+const kvBase = process.env.METADATA_BASE || 'https://metadata.speedcdnjs.com';
 const cache = {};
 
 // Clean cache hits that are ready to be purged


### PR DESCRIPTION
## Type of Change

- **Utilities:** Libs

## What issue does this relate to?

N/A

### What should this PR do?

Allows setting the base URL for the metadata API via an environment variable -- this is so that our staging API server can use our staging metadata API for testing. 

### What are the acceptance criteria?

When the env var is set, the API server correctly uses the set metadata API. This has been tested on staging.