### PR TITLE
Disable caching throughout server with env var

### DIFF
--- a/middleware/errors.js
+++ b/middleware/errors.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 
 // Local imports
 const notFound = require('../utils/not_found');
+const cache = require('../utils/cache');
 
 module.exports = {
     notFound: (req, res, next) => {
@@ -12,6 +13,9 @@ module.exports = {
     error: (err, req, res, next) => {
         console.error(err.stack);
         Sentry.captureException(err);
+
+        // Never cache this
+        cache(res, -1);
 
         // Send the error response
         res.status(500).json({

--- a/routes/libraries.js
+++ b/routes/libraries.js
@@ -10,8 +10,8 @@ const queryArray = require('../utils/query_array');
 
 // App constants
 const index = algoliasearch('2QWLVLXZB6', 'e16bd99a5c7a8fccae13ad40762eec3c').initIndex('libraries');
-const validSearchFields = ['name', 'alternativeNames', 'github.​repo', 'description', 'keywords', 'filename',
-    'repositories.​url', 'github.​user', 'maintainers.​name'];
+const validSearchFields = ['name', 'alternativeNames', 'github.repo', 'description', 'keywords', 'filename',
+    'repositories.url', 'github.user', 'maintainers.name'];
 const maxQueryLength = 512;
 
 // Search the algolia index in browser mode

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,4 +1,11 @@
 module.exports = (res, age, immutable = false) => {
+    if (age === -1 || process.env.DISABLE_CACHING === '1') {
+        res.setHeader('Expires', '0');
+        res.setHeader('Pragma', 'no-cache');
+        res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+        return;
+    }
+
     res.setHeader('Expires',
         new Date(Date.now() + age * 1000).toUTCString());
     res.setHeader('Cache-Control',

--- a/utils/libraries.js
+++ b/utils/libraries.js
@@ -64,12 +64,14 @@ const jsonFetch = async url => {
     }
 
     // Store in cache
-    cache[url] = {
-        expires: Date.now() + 5 * 60 * 1000,
-        purge: Date.now() + 10 * 60 * 1000,
-        data: json,
-        fetching: false,
-    };
+    if (process.env.DISABLE_CACHING !== '1') {
+        cache[url] = {
+            expires: Date.now() + 5 * 60 * 1000,
+            purge: Date.now() + 10 * 60 * 1000,
+            data: json,
+            fetching: false,
+        };
+    }
     return json;
 };
 


### PR DESCRIPTION
## Type of Change

- **Utilities:** Caching, KV fetching

## What issue does this relate to?

N/A

### What should this PR do?

Disables cache headers + internal KV caching through the `DISABLE_CACHING` env var when it is set to `1`.

### What are the acceptance criteria?

When set, no-cache headers are returned and KV results are not cached. Tested on staging.