### PR TITLE
Disable response properties test for /libraries with version fields

### DIFF
--- a/tests/suite/libraries.js
+++ b/tests/suite/libraries.js
@@ -1,4 +1,4 @@
-const { describe, it, before } = require('mocha');
+const { describe, it, xit, before } = require('mocha');
 const { expect } = require('chai');
 const request = require('../base');
 const fetch = require('../fetch');
@@ -140,7 +140,8 @@ describe('/libraries', () => {
             done();
         });
         describe('Library object', () => {
-            it('is an object with \'name\', \'latest\' and requested \'version\' properties', done => {
+            // FIXME
+            xit('is an object with \'name\', \'latest\' and requested \'version\' properties', done => {
                 for (const result of response.body.results) {
                     expect(result).to.have.property('name').that.is.a('string');
                     try {


### PR DESCRIPTION
## Type of Change

- **Tests:**

## What issue does this relate to?

N/A

### What should this PR do?

Disables the continually failing spec as it is unknown when the test will be able to resolve the invalid data that is present in the Algolia index.

/libraries : Requesting a field (?fields=version) : Library object : is an object with 'name', 'latest' and requested 'version' properties

### What are the acceptance criteria?

Test suite passes.