### PR TITLE
Look for start string to reduce failures

### DIFF
--- a/tests/run.js
+++ b/tests/run.js
@@ -59,7 +59,7 @@ const main = () => {
         }
 
         // Run the mocha tests if the server started
-        if (!exiting && `${data}`.trim().startsWith('Listening on ')) {
+        if (!exiting && `${data}`.trim().indexOf(`Listening on http://0.0.0.0:${Number(process.env.PORT || 5050)}`) !== -1) {
             clearTimeout(timeout);
             mocha(server);
         }


### PR DESCRIPTION
## Type of Change

- **Tests:** Runner

## What issue does this relate to?

N/A

### What should this PR do?

Searches for the server start string instead of just looking at the start of the incoming stdout data. Hopefully, this should reduce test failures due to the start string not being detected.

### What are the acceptance criteria?

Tests pass.