### PR TITLE
Add dedicated health route to API

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -12,6 +12,16 @@ module.exports = app => {
         res.redirect(301, 'https://cdnjs.com/api');
     });
 
+    // Respond that the API is up
+    app.get('/health', (req, res) => {
+        // Don't cache health, ensure its always live
+        cache(res, -1);
+
+        // Respond
+        res.type('text/plain');
+        res.send('OK');
+    });
+
     // Don't ever index anything on the API
     app.get('/robots.txt', (req, res) => {
         // Set a 355 day (same as CDN) life on this response

--- a/tests/suite/index.js
+++ b/tests/suite/index.js
@@ -29,7 +29,7 @@ describe('/', () => {
 
 describe('/health', () => {
     const path = '/health';
-    const test = () => request().get(path).redirects(0);
+    const test = () => request().get(path);
     let response;
     before('fetch endpoint', done => {
         fetch(test).then(res => {

--- a/tests/suite/index.js
+++ b/tests/suite/index.js
@@ -27,6 +27,31 @@ describe('/', () => {
     });
 });
 
+describe('/health', () => {
+    const path = '/health';
+    const test = () => request().get(path).redirects(0);
+    let response;
+    before('fetch endpoint', done => {
+        fetch(test).then(res => {
+            response = res;
+            done();
+        });
+    });
+    testCors(path, () => response);
+    it('returns the correct Cache headers', done => {
+        expect(response).to.have.header('Expires', '0');
+        expect(response).to.have.header('Pragma', 'no-cache');
+        expect(response).to.have.header('Cache-Control', 'no-cache, no-store, must-revalidate');
+        done();
+    });
+    it('returns on OK message with a 200 status code', done => {
+        expect(response).to.have.status(200);
+        expect(response).to.be.text;
+        expect(response.text).to.eq('OK');
+        done();
+    });
+});
+
 describe('/robots.txt', () => {
     const path = '/robots.txt';
     const test = () => request().get(path);


### PR DESCRIPTION
## Type of Change

- **Routes:** health
- **Tests:** health route

## What issue does this relate to?

N/A

### What should this PR do?

Introduces a new health route that always returns a 200 `OK` message with no caching.

### What are the acceptance criteria?

Requests to /health receive a 200 response code and an `OK` message, with headers to ensure this response is not cached.