### PR TITLE
Add caching for Algolia calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Included with this project is a dependency lock file. This is used to ensure tha
 of the project are using the same version of dependencies for consistency. You can install the
 dependencies following this lock file by running:
 
-```shell script
+```sh
 npm ci
 ```
 
@@ -30,7 +30,7 @@ Once the dependencies are installed, which includes the Wrangler CLI for Cloudfl
 to create the KV namespace for data caching before the API can be run. This command will ask you to
 authenticate with a Cloudflare account, so that the Workers KV namespace can be created:
 
-```shell script
+```sh
 wrangler kv:namespace create CACHE --preview
 ```
 
@@ -40,7 +40,7 @@ provided by the CLI.
 With the KV namespace ready to go, the API server is now ready to run in development mode. To start
 the server in development mode, run:
 
-```shell script
+```sh
 npm run dev
 ```
 
@@ -52,7 +52,7 @@ deployed in a development context to Cloudflare's Workers runtime.
 Our full set of tests (linting & a mocha+chai test suite using Miniflare to run the worker locally)
 can be run at any time with:
 
-```shell script
+```sh
 npm test
 ```
 
@@ -65,20 +65,20 @@ API server.
 To help enforce this, we use both eslint and echint in our testing. To run eslint at any time, which
 checks the code style of any JavaScript, you can use:
 
-```shell script
+```sh
 npm run test:eslint
 ```
 
 eslint also provides automatic fixing capabilities, these can be run against the codebase with:
 
-```shell script
+```sh
 npm run test:eslint:fix
 ```
 
 The more generic rules defined in the [editorconfig file](.editorconfig) apply to all files in the
 repository and this is enforced by echint, which can be run at any time with:
 
-```shell script
+```sh
 npm run test:echint
 ```
 
@@ -92,7 +92,7 @@ this is perfect, a human should always review changes!
 The mocha test suite can be run at any time with the following command (it will build the worker
 using Wrangler, and then run it with Miniflare during the Mocha+Chai test suite):
 
-```shell script
+```sh
 npm run test:mocha
 ```
 
@@ -122,7 +122,7 @@ a Sentry release with full source maps.
 Before deploying, ensure that you generate the required KV namespace for the environment you are
 deploying to and update [`wrangler.toml`](wrangler.toml) to use the correct ID:
 
-```shell script
+```sh
 wrangler kv:namespace create CACHE --env=staging
 # or
 wrangler kv:namespace create CACHE --env=production

--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ dependencies following this lock file by running:
 npm ci
 ```
 
-Once the dependencies are installed, which includes the Wrangler CLI for Cloudflare Workers, we need
-to create the KV namespace for data caching before the API can be run. This command will ask you to
-authenticate with a Cloudflare account, so that the Workers KV namespace can be created:
+Once the dependencies are installed, which includes the Wrangler CLI for Cloudflare Workers, you
+need to create the KV namespace for data caching before the API can be run. This command will ask
+you to authenticate with a Cloudflare account, so that the Workers KV namespace can be created:
 
 ```sh
 wrangler kv:namespace create CACHE --preview
 ```
 
-Update the existing `preview_id` in the [`wrangler.toml`](wrangler.toml) file to the new preview ID
-provided by the CLI.
+Copy the new `preview_id` returned by the command and replace the existing `preview_id` in
+[`wrangler.toml`](wrangler.toml).
 
-With the KV namespace ready to go, the API server is now ready to run in development mode. To start
-the server in development mode, run:
+With the KV namespace setup, the API server is now ready to run in development mode. To start the
+server in development mode, run:
 
 ```sh
 npm run dev

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ deploying to staging (api.cdnjs.dev) and production (api.cdnjs.com) based on com
 staging/production branches, automatically handling not only deploying the worker but also creating
 a Sentry release with full source maps.
 
+Before deploying, ensure that you generate the required KV namespace for the environment you are
+deploying to and update [`wrangler.toml`](wrangler.toml) to use the correct ID:
+
+```shell script
+wrangler kv:namespace create CACHE --env=staging
+# or
+wrangler kv:namespace create CACHE --env=production
+```
+
 To deploy to staging (assuming you have write access to this repository), run `make deploy-staging`.
 This will force-push your latest local commit to the staging branch, which will trigger GitHub
 Actions to run and deploy your worker to Cloudflare Workers.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Looking for the documentation on our API?
 
 This project uses [Node.js](https://nodejs.org) for development, and is deployed as a
 [Cloudflare Worker](https://workers.cloudflare.com/). Please make sure you have a Node.js version
-installed that matches our defined requirement in the [.nvmrc](.nvmrc) file for this project.
+installed that matches our defined requirement in the [`.nvmrc`](.nvmrc) file for this project.
 
 Included with this project is a dependency lock file. This is used to ensure that all installations
 of the project are using the same version of dependencies for consistency. You can install the
@@ -26,8 +26,19 @@ dependencies following this lock file by running:
 npm ci
 ```
 
-Once the dependencies are installed, which includes the Wrangler CLI for Cloudflare Workers, the API
-server is ready to run in development mode. To start the server in development mode, run:
+Once the dependencies are installed, which includes the Wrangler CLI for Cloudflare Workers, we need
+to create the KV namespace for data caching before the API can be run. This command will ask you to
+authenticate with a Cloudflare account, so that the Workers KV namespace can be created:
+
+```shell script
+wrangler kv:namespace create CACHE --preview
+```
+
+Update the existing `preview_id` in the [`wrangler.toml`](wrangler.toml) file to the new preview ID
+provided by the CLI.
+
+With the KV namespace ready to go, the API server is now ready to run in development mode. To start
+the server in development mode, run:
 
 ```shell script
 npm run dev

--- a/src/routes/libraries.js
+++ b/src/routes/libraries.js
@@ -12,6 +12,14 @@ const validSearchFields = [ 'name', 'alternativeNames', 'github.repo', 'descript
 const maxQueryLength = 512;
 
 /**
+ * Convert an ArrayBuffer to a hex string.
+ *
+ * @param {ArrayBuffer} buf Buffer to convert.
+ * @return {string}
+ */
+const bufToHex = buf => Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('');
+
+/**
  * Browse an Algolia index to get all objects matching a query.
  *
  * @param {string} query Query to fetch matching objects for.
@@ -22,11 +30,11 @@ const browse = async (query, searchFields) => {
     // Normalize the search fields
     const fields = searchFields.filter(field => validSearchFields.includes(field)).sort();
 
-    // Check if we have a cached result for this query
+    // Check if there is a cached result for this query
     const cacheKey = await crypto.subtle.digest(
         { name: 'SHA-512' },
         new TextEncoder().encode(`${query}:${fields.join(',')}`),
-    ).then(buf => `libraries:${Array.from(new Uint8Array(buf)).map(b => b.toString(16).padStart(2, '0')).join('')}`);
+    ).then(buf => `libraries:${bufToHex(buf)}`);
     const cached = await CACHE.get(cacheKey, { type: 'json' });
     if (cached) return cached;
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -29,6 +29,9 @@ USE_ORIGIN_PCT = 0
 
 [env.production]
 route = "api.cdnjs.com/*"
+kv_namespaces = [
+    { binding = "CACHE", id = "c2922fcf1af643658d6769859b913134" }
+]
 
 [env.production.vars]
 DISABLE_CACHING = false

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,6 +15,9 @@ USE_ORIGIN_PCT = 0
 
 [env.staging]
 route = "api.cdnjs.dev/*"
+kv_namespaces = [
+    { binding = "CACHE", id = "34b159dab6f840ce9c17e4d0730ead12" }
+]
 
 [env.staging.vars]
 DISABLE_CACHING = false

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,9 @@
 name = "cdnjs-api-worker"
 main = "src/index.js"
 compatibility_date = "2022-05-20"
+kv_namespaces = [
+    { binding = "CACHE", id = "", preview_id = "845ae1599dcf4d75950b61201a951b73" }
+]
 
 [vars]
 DISABLE_CACHING = false


### PR DESCRIPTION
## Type of Change

- **Routes:** Libraries

## What issue does this relate to?

N/A

### What should this PR do?

Adds KV-based caching to Aloglia index calls, with the aim to reduce the number of calls we're actually making to Algolia by caching results for each unique query in KV for 15 minutes at a time.

TODO:

- Is 15 minutes a good expiration for the cached results?
- Production KV namespace needs to be created

### What are the acceptance criteria?

Repeat calls to the libraries endpoint with identical queries will rely on cached results for 15 minutes, instead of making API calls to Aloglia every time.

Identical requests with query params in a different order, or a fields list containing the same values but in a different order, will be normalized and share the same cached results.