### PR TITLE
Allow trailing slashes

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,37 +1,62 @@
 import cache from '../utils/cache';
 
 /**
+ * Handle GET / requests.
+ *
+ * @param {import('hono').Context} ctx Request context.
+ * @return {Response}
+ */
+const handleGet = ctx => {
+    // Set a 355 day (same as CDN) life on this response
+    // This is also immutable
+    cache(ctx, 355 * 24 * 60 * 60, true);
+
+    // Redirect to the API docs
+    return ctx.redirect('https://cdnjs.com/api', 301);
+};
+
+/**
+ * Handle GET /health requests.
+ *
+ * @param {import('hono').Context} ctx Request context.
+ * @return {Response}
+ */
+const handleGetHealth = ctx => {
+    // Don't cache health, ensure its always live
+    cache(ctx, -1);
+
+    // Respond
+    return ctx.text('OK');
+};
+
+/**
+ * Handle GET /robots.txt requests.
+ *
+ * @param {import('hono').Context} ctx Request context.
+ * @return {Response}
+ */
+const handleGetRobotsTxt = ctx => {
+    // Set a 355 day (same as CDN) life on this response
+    // This is also immutable
+    cache(ctx, 355 * 24 * 60 * 60, true);
+
+    // Disallow all robots
+    return ctx.text('User-agent: *\nDisallow: /');
+};
+
+/**
  * Register core routes.
  *
  * @param {import('hono').Hono} app App instance.
  */
 export default app => {
     // Redirect root the API docs
-    app.get('/', ctx => {
-        // Set a 355 day (same as CDN) life on this response
-        // This is also immutable
-        cache(ctx, 355 * 24 * 60 * 60, true);
-
-        // Redirect to the API docs
-        return ctx.redirect('https://cdnjs.com/api', 301);
-    });
+    app.get('/', handleGet);
 
     // Respond that the API is up
-    app.get('/health', ctx => {
-        // Don't cache health, ensure its always live
-        cache(ctx, -1);
-
-        // Respond
-        return ctx.text('OK');
-    });
+    app.get('/health', handleGetHealth);
+    app.get('/health/', handleGetHealth);
 
     // Don't ever index anything on the API
-    app.get('/robots.txt', ctx => {
-        // Set a 355 day (same as CDN) life on this response
-        // This is also immutable
-        cache(ctx, 355 * 24 * 60 * 60, true);
-
-        // Disallow all robots
-        return ctx.text('User-agent: *\nDisallow: /');
-    });
+    app.get('/robots.txt', handleGetRobotsTxt);
 };

--- a/src/routes/index.spec.js
+++ b/src/routes/index.spec.js
@@ -44,6 +44,13 @@ describe('/health', () => {
         expect(response).to.be.text;
         expect(response.text).to.eq('OK');
     });
+
+    // Test with a trailing slash
+    it('responds to requests with a trailing slash', async () => {
+        const res = await request(path + '/');
+        expect(res).to.have.status(200);
+        expect(res.body).to.deep.equal(response.body);
+    });
 });
 
 describe('/robots.txt', () => {

--- a/src/routes/libraries.js
+++ b/src/routes/libraries.js
@@ -61,61 +61,70 @@ const browse = async (query, searchFields) => {
 };
 
 /**
+ * Handle GET /libraries requests.
+ *
+ * @param {import('hono').Context} ctx Request context.
+ * @return {Promise<Response>}
+ */
+const handleGetLibraries = async ctx => {
+    // Get the index results
+    const searchFields = queryArray(ctx.req.queries('search_fields'));
+    const results = await browse(
+        (ctx.req.query('search') || '').toString().slice(0, maxQueryLength),
+        searchFields.includes('*') ? [] : searchFields,
+    );
+
+    // Transform the results into our filtered array
+    const requestedFields = queryArray(ctx.req.queries('fields'));
+    const response = results.filter(hit => {
+        if (hit?.name) return true;
+        console.warn('Found bad entry in Algolia data');
+        console.info(hit);
+        ctx.sentry?.withScope(scope => {
+            scope.setExtra('hit', hit);
+            ctx.sentry.captureException(new Error('Bad entry in Algolia data'));
+        });
+        return false;
+    }).map(hit => filter(
+        {
+            // Ensure name is first prop
+            name: hit.name,
+            // Custom latest prop
+            latest: hit.filename && hit.version ? 'https://cdnjs.cloudflare.com/ajax/libs/' + hit.name + '/' + hit.version + '/' + hit.filename : null,
+            // All other hit props
+            ...hit,
+        },
+        [
+            // Always send back name & latest
+            'name',
+            'latest',
+            // Send back whatever else was requested
+            ...requestedFields,
+        ],
+        requestedFields.includes('*'), // Send all if they have '*'
+    ));
+
+    // If they want less data, allow that
+    const limit = ctx.req.query('limit') && Number(ctx.req.query('limit'));
+    const trimmed = limit ? response.slice(0, limit) : response;
+
+    // Set a 6 hour life on this response
+    cache(ctx, 6 * 60 * 60);
+
+    // Send the response
+    return respond(ctx, {
+        results: trimmed,
+        total: trimmed.length, // Total results we're sending back
+        available: response.length, // Total number available without trimming
+    });
+};
+
+/**
  * Register libraries routes.
  *
  * @param {import('hono').Hono} app App instance.
  */
 export default app => {
-    app.get('/libraries', async ctx => {
-        // Get the index results
-        const searchFields = queryArray(ctx.req.queries('search_fields'));
-        const results = await browse(
-            (ctx.req.query('search') || '').toString().slice(0, maxQueryLength),
-            searchFields.includes('*') ? [] : searchFields,
-        );
-
-        // Transform the results into our filtered array
-        const requestedFields = queryArray(ctx.req.queries('fields'));
-        const response = results.filter(hit => {
-            if (hit?.name) return true;
-            console.warn('Found bad entry in Algolia data');
-            console.info(hit);
-            ctx.sentry?.withScope(scope => {
-                scope.setExtra('hit', hit);
-                ctx.sentry.captureException(new Error('Bad entry in Algolia data'));
-            });
-            return false;
-        }).map(hit => filter(
-            {
-                // Ensure name is first prop
-                name: hit.name,
-                // Custom latest prop
-                latest: hit.filename && hit.version ? 'https://cdnjs.cloudflare.com/ajax/libs/' + hit.name + '/' + hit.version + '/' + hit.filename : null,
-                // All other hit props
-                ...hit,
-            },
-            [
-                // Always send back name & latest
-                'name',
-                'latest',
-                // Send back whatever else was requested
-                ...requestedFields,
-            ],
-            requestedFields.includes('*'), // Send all if they have '*'
-        ));
-
-        // If they want less data, allow that
-        const limit = ctx.req.query('limit') && Number(ctx.req.query('limit'));
-        const trimmed = limit ? response.slice(0, limit) : response;
-
-        // Set a 6 hour life on this response
-        cache(ctx, 6 * 60 * 60);
-
-        // Send the response
-        return respond(ctx, {
-            results: trimmed,
-            total: trimmed.length, // Total results we're sending back
-            available: response.length, // Total number available without trimming
-        });
-    });
+    app.get('/libraries', handleGetLibraries);
+    app.get('/libraries/', handleGetLibraries);
 };

--- a/src/routes/libraries.spec.js
+++ b/src/routes/libraries.spec.js
@@ -58,6 +58,13 @@ describe('/libraries', () => {
                 }
             });
         });
+
+        // Test with a trailing slash
+        it('responds to requests with a trailing slash', async () => {
+            const res = await request(path + '/');
+            expect(res).to.have.status(200);
+            expect(res.body).to.deep.equal(response.body);
+        });
     });
 
     describe('Requesting human response (?output=human)', () => {

--- a/src/routes/library.js
+++ b/src/routes/library.js
@@ -18,144 +18,162 @@ const extensions = Object.keys(files);
 const whitelisted = file => extensions.includes(file.split('.').slice(-1)[0]);
 
 /**
+ * Handle GET /libraries/:library/:version requests.
+ *
+ * @param {import('hono').Context} ctx Request context.
+ * @return {Promise<Response>}
+ */
+const handleGetLibraryVersion = async ctx => {
+    // Get the library
+    const lib = await library(ctx.req.param('library'), ctx.sentry).catch(err => {
+        if (err.status === 404) return;
+        throw err;
+    });
+    if (!lib) return notFound(ctx, 'Library');
+
+    // Get the version
+    const version = await libraryVersion(lib.name, ctx.req.param('version')).catch(err => {
+        if (err.status === 404) return;
+        throw err;
+    });
+    if (!version) return notFound(ctx, 'Version');
+
+    // Build the object
+    const results = {
+        name: lib.name,
+        version: ctx.req.param('version'),
+        rawFiles: version,
+        files: version.filter(whitelisted),
+        sri: null,
+    };
+
+    // Generate the initial filtered response (without SRI data)
+    const requestedFields = queryArray(ctx.req.queries('fields'));
+    const response = filter(
+        results,
+        requestedFields,
+        // If they requested no fields or '*', send them all
+        !requestedFields.length || requestedFields.includes('*'),
+    );
+
+    // Load SRI data if needed
+    if ('sri' in response) {
+        // Get SRI for version
+        const latestSriData = await libraryVersionSri(lib.name, ctx.req.param('version')).catch(() => {});
+        response.sri = sriForVersion(lib.name, ctx.req.param('version'), version, latestSriData, ctx.sentry);
+    }
+
+    // Set a 355 day (same as CDN) life on this response
+    // This is also immutable as a version will never change
+    cache(ctx, 355 * 24 * 60 * 60, true);
+
+    // Send the response
+    return respond(ctx, response);
+};
+
+/**
+ * Handle GET /libraries/:library requests.
+ *
+ * @param {import('hono').Context} ctx Request context.
+ * @return {Promise<Response>}
+ */
+const handleGetLibrary = async ctx => {
+    // Get the library
+    const lib = await library(ctx.req.param('library'), ctx.sentry).catch(err => {
+        if (err.status === 404) return;
+        throw err;
+    });
+    if (!lib) return notFound(ctx, 'Library');
+
+    // Generate the initial filtered response (without SRI, versions or assets data)
+    const requestedFields = queryArray(ctx.req.queries('fields'));
+    const response = filter(
+        {
+            // Ensure name is first prop
+            name: lib.name,
+            // Custom latest prop (and SRI value)
+            latest: lib.filename && lib.version ? 'https://cdnjs.cloudflare.com/ajax/libs/' + lib.name + '/' + lib.version + '/' + lib.filename : null,
+            sri: null,
+            // All other lib props
+            ...lib,
+            versions: null,
+            assets: null,
+        },
+        requestedFields,
+        // If they requested no fields or '*', send them all
+        !requestedFields.length || requestedFields.includes('*'),
+    );
+
+    // Get versions if needed
+    if ('versions' in response) response.versions = await libraryVersions(lib.name);
+
+    // Get assets if needed, inject SRI and do whitelist filtering
+    // Returning assets for all versions is deprecated, we only return the latest version in the array
+    if ('assets' in response) {
+        if (!lib.version) response.assets = [];
+        else {
+            // Fetch the assets for the version
+            const assets = await libraryVersion(lib.name, lib.version);
+
+            // Fetch the SRI data, ignore errors as they'll be reported by sriForVersion
+            const sriData = await libraryVersionSri(lib.name, lib.version).catch(() => {});
+
+            // Produce the assets array with just the latest version
+            response.assets = [ {
+                version: lib.version,
+                files: assets.filter(whitelisted),
+                rawFiles: assets,
+                sri: sriForVersion(lib.name, lib.version, assets, sriData, ctx.sentry),
+            } ];
+        }
+    }
+
+    // Load SRI for latest if needed
+    if ('sri' in response) {
+        if (lib.filename && lib.version) {
+            // Handle if we've already fetched SRI
+            if ('assets' in response) {
+                const latestVersion = response.assets.find(entry => entry.version === lib.version);
+                if (latestVersion) {
+                    if (lib.filename in latestVersion.sri) {
+                        response.sri = latestVersion.sri[lib.filename];
+                    }
+                }
+            }
+
+            // If no SRI value yet, fetch
+            if (!response.sri) {
+                // Get SRI for version, ignore errors as they'll be reported by sriForVersion
+                const latestSriData = await libraryVersionSri(lib.name, lib.version).catch(() => {});
+                response.sri = sriForVersion(
+                    lib.name,
+                    lib.version,
+                    [ lib.filename ],
+                    latestSriData,
+                    ctx.sentry,
+                )[lib.filename] || null;
+            }
+        }
+    }
+
+    // Set a 6 hour life on this response
+    cache(ctx, 6 * 60 * 60);
+
+    // Send the response
+    return respond(ctx, response);
+};
+
+/**
  * Register library routes.
  *
  * @param {import('hono').Hono} app App instance.
  */
 export default app => {
     // Library version
-    app.get('/libraries/:library/:version', async ctx => {
-        // Get the library
-        const lib = await library(ctx.req.param('library'), ctx.sentry).catch(err => {
-            if (err.status === 404) return;
-            throw err;
-        });
-        if (!lib) return notFound(ctx, 'Library');
-
-        // Get the version
-        const version = await libraryVersion(lib.name, ctx.req.param('version')).catch(err => {
-            if (err.status === 404) return;
-            throw err;
-        });
-        if (!version) return notFound(ctx, 'Version');
-
-        // Build the object
-        const results = {
-            name: lib.name,
-            version: ctx.req.param('version'),
-            rawFiles: version,
-            files: version.filter(whitelisted),
-            sri: null,
-        };
-
-        // Generate the initial filtered response (without SRI data)
-        const requestedFields = queryArray(ctx.req.queries('fields'));
-        const response = filter(
-            results,
-            requestedFields,
-            // If they requested no fields or '*', send them all
-            !requestedFields.length || requestedFields.includes('*'),
-        );
-
-        // Load SRI data if needed
-        if ('sri' in response) {
-            // Get SRI for version
-            const latestSriData = await libraryVersionSri(lib.name, ctx.req.param('version')).catch(() => {});
-            response.sri = sriForVersion(lib.name, ctx.req.param('version'), version, latestSriData, ctx.sentry);
-        }
-
-        // Set a 355 day (same as CDN) life on this response
-        // This is also immutable as a version will never change
-        cache(ctx, 355 * 24 * 60 * 60, true);
-
-        // Send the response
-        return respond(ctx, response);
-    });
+    app.get('/libraries/:library/:version', handleGetLibraryVersion);
+    app.get('/libraries/:library/:version/', handleGetLibraryVersion);
 
     // Library
-    app.get('/libraries/:library', async ctx => {
-        // Get the library
-        const lib = await library(ctx.req.param('library'), ctx.sentry).catch(err => {
-            if (err.status === 404) return;
-            throw err;
-        });
-        if (!lib) return notFound(ctx, 'Library');
-
-        // Generate the initial filtered response (without SRI, versions or assets data)
-        const requestedFields = queryArray(ctx.req.queries('fields'));
-        const response = filter(
-            {
-                // Ensure name is first prop
-                name: lib.name,
-                // Custom latest prop (and SRI value)
-                latest: lib.filename && lib.version ? 'https://cdnjs.cloudflare.com/ajax/libs/' + lib.name + '/' + lib.version + '/' + lib.filename : null,
-                sri: null,
-                // All other lib props
-                ...lib,
-                versions: null,
-                assets: null,
-            },
-            requestedFields,
-            // If they requested no fields or '*', send them all
-            !requestedFields.length || requestedFields.includes('*'),
-        );
-
-        // Get versions if needed
-        if ('versions' in response) response.versions = await libraryVersions(lib.name);
-
-        // Get assets if needed, inject SRI and do whitelist filtering
-        // Returning assets for all versions is deprecated, we only return the latest version in the array
-        if ('assets' in response) {
-            if (!lib.version) response.assets = [];
-            else {
-                // Fetch the assets for the version
-                const assets = await libraryVersion(lib.name, lib.version);
-
-                // Fetch the SRI data, ignore errors as they'll be reported by sriForVersion
-                const sriData = await libraryVersionSri(lib.name, lib.version).catch(() => {});
-
-                // Produce the assets array with just the latest version
-                response.assets = [ {
-                    version: lib.version,
-                    files: assets.filter(whitelisted),
-                    rawFiles: assets,
-                    sri: sriForVersion(lib.name, lib.version, assets, sriData, ctx.sentry),
-                } ];
-            }
-        }
-
-        // Load SRI for latest if needed
-        if ('sri' in response) {
-            if (lib.filename && lib.version) {
-                // Handle if we've already fetched SRI
-                if ('assets' in response) {
-                    const latestVersion = response.assets.find(entry => entry.version === lib.version);
-                    if (latestVersion) {
-                        if (lib.filename in latestVersion.sri) {
-                            response.sri = latestVersion.sri[lib.filename];
-                        }
-                    }
-                }
-
-                // If no SRI value yet, fetch
-                if (!response.sri) {
-                    // Get SRI for version, ignore errors as they'll be reported by sriForVersion
-                    const latestSriData = await libraryVersionSri(lib.name, lib.version).catch(() => {});
-                    response.sri = sriForVersion(
-                        lib.name,
-                        lib.version,
-                        [ lib.filename ],
-                        latestSriData,
-                        ctx.sentry,
-                    )[lib.filename] || null;
-                }
-            }
-        }
-
-        // Set a 6 hour life on this response
-        cache(ctx, 6 * 60 * 60);
-
-        // Send the response
-        return respond(ctx, response);
-    });
+    app.get('/libraries/:library', handleGetLibrary);
+    app.get('/libraries/:library/', handleGetLibrary);
 };

--- a/src/routes/library.spec.js
+++ b/src/routes/library.spec.js
@@ -38,6 +38,13 @@ describe('/libraries/:library/:version', () => {
                         expect(Object.keys(response.body)).to.have.lengthOf(5);
                     });
                 });
+
+                // Test with a trailing slash
+                it('responds to requests with a trailing slash', async () => {
+                    const res = await request(path + '/');
+                    expect(res).to.have.status(200);
+                    expect(res.body).to.deep.equal(response.body);
+                });
             });
 
             describe('Requesting human response (?output=human)', () => {
@@ -346,6 +353,13 @@ describe('/libraries/:library', () => {
                         }
                     });
                 });
+            });
+
+            // Test with a trailing slash
+            it('responds to requests with a trailing slash', async () => {
+                const res = await request(path + '/');
+                expect(res).to.have.status(200);
+                expect(res.body).to.deep.equal(response.body);
             });
         });
 

--- a/src/routes/stats.js
+++ b/src/routes/stats.js
@@ -5,27 +5,36 @@ import queryArray from '../utils/queryArray.js';
 import respond from '../utils/respond.js';
 
 /**
+ * Handle GET /stats requests.
+ *
+ * @param {import('hono').Context} ctx Request context.
+ * @return {Promise<Response>}
+ */
+const handleGetStats = async ctx => {
+    const libs = await libraries();
+    const requestedFields = queryArray(ctx.req.queries('fields'));
+    const response = filter(
+        {
+            libraries: libs.length,
+        },
+        requestedFields,
+        // If they requested no fields or '*', send them all
+        !requestedFields.length || requestedFields.includes('*'),
+    );
+
+    // Set a 6 hour life on this response
+    cache(ctx, 6 * 60 * 60);
+
+    // Send the response
+    return respond(ctx, response);
+};
+
+/**
  * Register stats routes.
  *
  * @param {import('hono').Hono} app App instance.
  */
 export default app => {
-    app.get('/stats', async ctx => {
-        const libs = await libraries();
-        const requestedFields = queryArray(ctx.req.queries('fields'));
-        const response = filter(
-            {
-                libraries: libs.length,
-            },
-            requestedFields,
-            // If they requested no fields or '*', send them all
-            !requestedFields.length || requestedFields.includes('*'),
-        );
-
-        // Set a 6 hour life on this response
-        cache(ctx, 6 * 60 * 60);
-
-        // Send the response
-        return respond(ctx, response);
-    });
+    app.get('/stats', handleGetStats);
+    app.get('/stats/', handleGetStats);
 };

--- a/src/routes/stats.spec.js
+++ b/src/routes/stats.spec.js
@@ -32,6 +32,13 @@ describe('/stats', () => {
                 expect(Object.keys(response.body)).to.have.lengthOf(1);
             });
         });
+
+        // Test with a trailing slash
+        it('responds to requests with a trailing slash', async () => {
+            const res = await request(path + '/');
+            expect(res).to.have.status(200);
+            expect(res.body).to.deep.equal(response.body);
+        });
     });
 
     describe('Requesting human response (?output=human)', () => {

--- a/src/routes/whitelist.js
+++ b/src/routes/whitelist.js
@@ -8,9 +8,9 @@ import respond from '../utils/respond.js';
  * Handle GET /whitelist requests.
  *
  * @param {import('hono').Context} ctx Request context.
- * @return {Promise<Response>}
+ * @return {Response}
  */
-const handleGetWhitelist = async ctx => {
+const handleGetWhitelist = ctx => {
     // Build the object
     const results = {
         extensions: Object.keys(files),

--- a/src/routes/whitelist.js
+++ b/src/routes/whitelist.js
@@ -5,32 +5,41 @@ import queryArray from '../utils/queryArray.js';
 import respond from '../utils/respond.js';
 
 /**
+ * Handle GET /whitelist requests.
+ *
+ * @param {import('hono').Context} ctx Request context.
+ * @return {Promise<Response>}
+ */
+const handleGetWhitelist = async ctx => {
+    // Build the object
+    const results = {
+        extensions: Object.keys(files),
+        categories: files,
+    };
+
+    // Generate the filtered response
+    const requestedFields = queryArray(ctx.req.queries('fields'));
+    const response = filter(
+        results,
+        requestedFields,
+        // If they requested no fields or '*', send them all
+        !requestedFields.length || requestedFields.includes('*'),
+    );
+
+    // Set a 6 hour life on this response
+    cache(ctx, 6 * 60 * 60);
+
+    // Send the response
+    return respond(ctx, response);
+};
+
+/**
  * Register whitelist routes.
  *
  * @param {import('hono').Hono} app App instance.
  */
 export default app => {
     // Whitelist
-    app.get('/whitelist', ctx => {
-        // Build the object
-        const results = {
-            extensions: Object.keys(files),
-            categories: files,
-        };
-
-        // Generate the filtered response
-        const requestedFields = queryArray(ctx.req.queries('fields'));
-        const response = filter(
-            results,
-            requestedFields,
-            // If they requested no fields or '*', send them all
-            !requestedFields.length || requestedFields.includes('*'),
-        );
-
-        // Set a 6 hour life on this response
-        cache(ctx, 6 * 60 * 60);
-
-        // Send the response
-        return respond(ctx, response);
-    });
+    app.get('/whitelist', handleGetWhitelist);
+    app.get('/whitelist/', handleGetWhitelist);
 };

--- a/src/routes/whitelist.spec.js
+++ b/src/routes/whitelist.spec.js
@@ -49,6 +49,13 @@ describe('/whitelist', () => {
                 }
             });
         });
+
+        // Test with a trailing slash
+        it('responds to requests with a trailing slash', async () => {
+            const res = await request(path + '/');
+            expect(res).to.have.status(200);
+            expect(res.body).to.deep.equal(response.body);
+        });
     });
 
     describe('Requesting human response (?output=human)', () => {


### PR DESCRIPTION
## Type of Change

- **Routes:** All routes

## What issue does this relate to?

Resolves #81

### What should this PR do?

Allows routes to be accessed with a trailing slash, and adds tests to ensure this regression does not occur again.

### What are the acceptance criteria?

Routes can be accessed with trailing slashes:

- /health/
- /stats/
- /whitelist/
- /libraries/
- /libraries/vue/
- /libraries/vue/3.2.40/