### PR TITLE
Return case-sensitive fields correctly

### DIFF
--- a/src/routes/libraries.js
+++ b/src/routes/libraries.js
@@ -7,9 +7,21 @@ import queryArray from '../utils/queryArray.js';
 import respond from '../utils/respond.js';
 
 const index = algolia().initIndex('libraries');
+
+// Fields configured in Algolia to be searchable
 const validSearchFields = [ 'name', 'alternativeNames', 'github.repo', 'description', 'keywords', 'filename',
     'repositories.url', 'github.user', 'maintainers.name' ];
+
+// Max query length that Algolia will accept
 const maxQueryLength = 512;
+
+// Map of lowercase fields to their proper case
+const mixedCaseFields = {
+    alternativenames: 'alternativeNames',
+    filetype: 'fileType',
+    originalname: 'originalName',
+    objectid: 'objectID',
+};
 
 /**
  * Convert an ArrayBuffer to a hex string.
@@ -75,7 +87,7 @@ const handleGetLibraries = async ctx => {
     );
 
     // Transform the results into our filtered array
-    const requestedFields = queryArray(ctx.req.queries('fields'));
+    const requestedFields = queryArray(ctx.req.queries('fields')).map(field => mixedCaseFields[field] || field);
     const response = results.filter(hit => {
         if (hit?.name) return true;
         console.warn('Found bad entry in Algolia data');

--- a/src/routes/libraries.spec.js
+++ b/src/routes/libraries.spec.js
@@ -152,6 +152,96 @@ describe('/libraries', () => {
         });
     });
 
+    describe('Requesting a case-sensitive field', () => {
+        describe('with the correct casing (?fields=fileType)', () => {
+            // Fetch the endpoint
+            const path = '/libraries?fields=fileType';
+            let response;
+            before('fetch endpoint', () => request(path).then(res => { response = res; }));
+
+            // Test the endpoint
+            testCors(path, () => response);
+            it('returns the correct Cache headers', () => {
+                expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
+            });
+            it('returns the correct status code', () => {
+                expect(response).to.have.status(200);
+            });
+            it('returns a JSON body with \'results\', \'total\' and \'available\' properties', () => {
+                expect(response).to.be.json;
+                expect(response.body).to.have.property('results').that.is.an('array');
+                expect(response.body).to.have.property('total').that.is.a('number');
+                expect(response.body).to.have.property('available').that.is.a('number');
+            });
+            it('returns all available hits', () => {
+                expect(response.body.results).to.have.lengthOf(response.body.total);
+                expect(response.body.results).to.have.lengthOf(response.body.available);
+            });
+            describe('Library object', () => {
+                it('is an object with \'name\', \'latest\' and requested \'fileType\' properties', () => {
+                    for (const result of response.body.results) {
+                        expect(result).to.have.property('name').that.is.a('string');
+                        try {
+                            expect(result).to.have.property('latest').that.is.a('string');
+                        } catch (_) {
+                            expect(result).to.have.property('latest').that.is.null;
+                        }
+                        expect(result).to.have.property('fileType').that.is.a('string');
+                    }
+                });
+                it('has no other properties', () => {
+                    for (const result of response.body.results) {
+                        expect(Object.keys(result)).to.have.lengthOf(3);
+                    }
+                });
+            });
+        });
+
+        describe('with incorrect casing (?fields=filetype)', () => {
+            // Fetch the endpoint
+            const path = '/libraries?fields=filetype';
+            let response;
+            before('fetch endpoint', () => request(path).then(res => { response = res; }));
+
+            // Test the endpoint
+            testCors(path, () => response);
+            it('returns the correct Cache headers', () => {
+                expect(response).to.have.header('Cache-Control', 'public, max-age=21600'); // Six hours
+            });
+            it('returns the correct status code', () => {
+                expect(response).to.have.status(200);
+            });
+            it('returns a JSON body with \'results\', \'total\' and \'available\' properties', () => {
+                expect(response).to.be.json;
+                expect(response.body).to.have.property('results').that.is.an('array');
+                expect(response.body).to.have.property('total').that.is.a('number');
+                expect(response.body).to.have.property('available').that.is.a('number');
+            });
+            it('returns all available hits', () => {
+                expect(response.body.results).to.have.lengthOf(response.body.total);
+                expect(response.body.results).to.have.lengthOf(response.body.available);
+            });
+            describe('Library object', () => {
+                it('is an object with \'name\', \'latest\' and requested \'fileType\' properties', () => {
+                    for (const result of response.body.results) {
+                        expect(result).to.have.property('name').that.is.a('string');
+                        try {
+                            expect(result).to.have.property('latest').that.is.a('string');
+                        } catch (_) {
+                            expect(result).to.have.property('latest').that.is.null;
+                        }
+                        expect(result).to.have.property('fileType').that.is.a('string');
+                    }
+                });
+                it('has no other properties', () => {
+                    for (const result of response.body.results) {
+                        expect(Object.keys(result)).to.have.lengthOf(3);
+                    }
+                });
+            });
+        });
+    });
+
     describe('Requesting multiple fields', () => {
         describe('through comma-separated string (?fields=filename,version)', () => {
             // Fetch the endpoint


### PR DESCRIPTION
## Type of Change

- **Routes:** Libraries handler

## What issue does this relate to?

Resolves #86

### What should this PR do?

Ensures that we are correctly maintaining the casing of requested fields when they are case-sensitive, for the libraries endpoint (e.g. `fields=fileType`)

### What are the acceptance criteria?

New tests correctly cover case-sensitive fields, and are passing. Requesting the `fileType` field on the libraries endpoint returns the field as expected, not null.