### PR TITLE
Temporarily disable missing SRI Sentry error

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -151,6 +151,9 @@ module.exports = {
         ],
         'no-unused-vars': [
             'error',
+            {
+                argsIgnorePattern: '^_',
+            },
         ],
         'no-unused-expressions': [
             'error',

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ commit hash).
 Alongside the normal error reporting that Sentry provides in the worker, we also fire out custom
 error events for certain issues to help with improving data consistency across cdnjs:
 
-- `Missing SRI entry` is fired if there is no SRI hash for a file
+<!-- - `Missing SRI entry` is fired if there is no SRI hash for a file -->
 - `Bad entry in Algolia data` is fired if an entry in Algolia is falsey, or if its name is falsey
 - `Bad entry in packages data` is fired if a package is falsey, or if its `name`/`version` is falsey
 

--- a/src/utils/sriForVersion.js
+++ b/src/utils/sriForVersion.js
@@ -5,10 +5,10 @@
  * @param {string} version Version of the library.
  * @param {string[]} files Names of the files for this version of the library.
  * @param {Object<string, string>} sriData SRI data for the libary version.
- * @param {import('toucan-js')} [sentry] Sentry instance for missing SRI reporting.
+ * @param {import('toucan-js')} [_sentry] Sentry instance for missing SRI reporting.
  * @return {Object<string, string>}
  */
-export default (library, version, files, sriData, sentry = undefined) => {
+export default (library, version, files, sriData, _sentry = undefined) => {
     // Build the SRI object
     const sri = {};
     for (const file of files) {
@@ -23,13 +23,13 @@ export default (library, version, files, sriData, sentry = undefined) => {
         // If we don't have an SRI entry, but expect one, error!
         if (file.endsWith('.js') || file.endsWith('.css')) {
             console.warn('Missing SRI entry for', fullFile);
-            sentry?.withScope(scope => {
-                scope.setTag('library', library);
-                scope.setTag('library.version', version);
-                scope.setTag('library.file', file);
-                scope.setTag('library.file.full', fullFile);
-                sentry.captureException(new Error('Missing SRI entry'));
-            });
+            // sentry?.withScope(scope => {
+            //     scope.setTag('library', library);
+            //     scope.setTag('library.version', version);
+            //     scope.setTag('library.file', file);
+            //     scope.setTag('library.file.full', fullFile);
+            //     sentry.captureException(new Error('Missing SRI entry'));
+            // });
         }
     }
 


### PR DESCRIPTION
## Type of Change

- **Utilities:** SRI

## What issue does this relate to?

N/A

### What should this PR do?

Temporarily disables the emitting of SRI missing errors to Sentry, as they have become too noisy, and it is a known issue generally until we have a chance to recompute all the SRI hashes.

### What are the acceptance criteria?

Error emitting disabled.
