### PR TITLE
Enable traces for workers observability

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -40,6 +40,12 @@ kv_namespaces = [
     { binding = "CACHE", id = "c2922fcf1af643658d6769859b913134" }
 ]
 
+[env.production.observability.logs]
+head_sampling_rate = 0.05
+
+[env.production.observability.traces]
+head_sampling_rate = 0.05
+
 [env.production.vars]
 DISABLE_CACHING = false
 METADATA_BASE = ""


### PR DESCRIPTION
## Type of Change

- **Something else:** Observability

## What issue does this relate to?

N/A

### What should this PR do?

Logs were enabled at 100% in #142 while debugging. We can also enable traces, and for production we should reduce the sampling rate for both due to the volume of traffic.

### What are the acceptance criteria?

Logs + traces populate in Cloudflare dashboard.