### PR TITLE
Move KV put to background with waitUntil

### DIFF
--- a/src/routes/libraries.js
+++ b/src/routes/libraries.js
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/cloudflare';
-import { env } from 'cloudflare:workers';
+import { env, waitUntil } from 'cloudflare:workers';
 
 import algolia from '../utils/algolia.js';
 import cache from '../utils/cache.js';
@@ -69,7 +69,7 @@ const browse = async (query, searchFields) => {
     });
 
     // Cache the results for 15 minutes
-    await env.CACHE.put(cacheKey, JSON.stringify(hits), { expirationTtl: 60 * 15 });
+    waitUntil(env.CACHE.put(cacheKey, JSON.stringify(hits), { expirationTtl: 60 * 15 }));
     return hits;
 };
 


### PR DESCRIPTION
## Type of Change

- **Routes:** /libraries

## What issue does this relate to?

N/A

### What should this PR do?

With tracing enabled in #144, it quickly became apparent that a large part of the slowdown when requesting /libraries is the KV put call that we wait for before returning results:

<img width="3446" height="748" alt="image" src="https://github.com/user-attachments/assets/724c7ac1-bfdf-48b7-b0d6-3dfe1b545f6a" />

This can instead be moved to the background via `waitUntil`, as to avoid not slowing down the request as much.

### What are the acceptance criteria?

/libraries continues work, KV caching continues to work.