### PR TITLE
Explicitly enable observability in production

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -41,9 +41,11 @@ kv_namespaces = [
 ]
 
 [env.production.observability.logs]
+enabled = true
 head_sampling_rate = 0.05
 
 [env.production.observability.traces]
+enabled = true
 head_sampling_rate = 0.05
 
 [env.production.vars]


### PR DESCRIPTION
## Type of Change

- **Something else:** Observability

## What issue does this relate to?

https://github.com/cdnjs/api-server/actions/runs/21768630275/job/62810812941#step:7:16

### What should this PR do?

Setting `enabled = true` is required, it does not get inherited.

### What are the acceptance criteria?

Once merged, deploy to production.
