### PR TITLE
Remove missing SRI warning log

### DIFF
--- a/src/utils/sriForVersion.js
+++ b/src/utils/sriForVersion.js
@@ -23,7 +23,6 @@ export default (library, version, files, sriData) => {
 
         // If we don't have an SRI entry, but expect one, error!
         if (file.endsWith('.js') || file.endsWith('.css')) {
-            console.warn('Missing SRI entry for', fullFile);
             // Sentry.withScope(scope => {
             //     scope.setTag('library', library);
             //     scope.setTag('library.version', version);


### PR DESCRIPTION
## Type of Change

- **Something else:** Logging

## What issue does this relate to?

N/A

### What should this PR do?

Further follow-up for #150, with logging at 100%, this warning is going to become too noisy. We already disabled the Sentry error due to the volume and noise, no reason to have this log still.

### What are the acceptance criteria?

No SRI missing logs generated.