### PR TITLE
Remove Wrangler binding IDs + disable telemetry

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
 name = "cdnjs-api-worker"
 main = "src/index.js"
+send_metrics = false
 compatibility_date = "2022-10-31"
 compatibility_flags = [ "nodejs_als" ]
 kv_namespaces = [ { binding = "CACHE" } ]


### PR DESCRIPTION
## Type of Change

- **Something else:** Config

## What issue does this relate to?

N/A

### What should this PR do?

Removes the explicit IDs set of the `CACHE` KV binding, as Wrangler/Cloudflare can now automatically infer these from the existing buckets, and this improves the DX for anyone who wishes to also run this locally / deploy it themselves.

Disables Wrangler sending telemetry data, as per https://github.com/cloudflare/workers-sdk/pull/12708#issuecomment-3988585895 they are significantly increasing the amount of data being collected in a way that no longer seems truly anonymized.

### What are the acceptance criteria?

Worker continues to deploy + function without issue.