### PR TITLE
Add queryCheck util to pass to filter

### DIFF
--- a/src/routes/libraries.js
+++ b/src/routes/libraries.js
@@ -4,7 +4,7 @@ import { env, waitUntil } from 'cloudflare:workers';
 import algolia from '../utils/algolia.js';
 import cache from '../utils/cache.js';
 import filter from '../utils/filter.js';
-import { queryArray } from '../utils/query.js';
+import { queryArray, queryCheck } from '../utils/query.js';
 import respond from '../utils/respond.js';
 
 // Fields configured in Algolia to be searchable
@@ -13,14 +13,6 @@ const validSearchFields = [ 'name', 'alternativeNames', 'github.repo', 'descript
 
 // Max query length that Algolia will accept (bytes)
 const maxQueryLength = 512;
-
-// Map of lowercase fields to their proper case
-const mixedCaseFields = {
-    alternativenames: 'alternativeNames',
-    filetype: 'fileType',
-    originalname: 'originalName',
-    objectid: 'objectID',
-};
 
 /**
  * Convert an ArrayBuffer to a hex string.
@@ -109,7 +101,7 @@ const handleGetLibraries = async ctx => {
     );
 
     // Transform the results into our filtered array
-    const requestedFields = queryArray(ctx.req.queries('fields')).map(field => mixedCaseFields[field] || field);
+    const requestedFields = queryCheck(ctx.req.queries('fields'), false);
     const response = results.filter(hit => {
         if (hit?.name) return true;
         console.warn('Found bad entry in Algolia data');
@@ -119,24 +111,13 @@ const handleGetLibraries = async ctx => {
             Sentry.captureException(new Error('Bad entry in Algolia data'));
         });
         return false;
-    }).map(hit => filter(
-        {
-            // Ensure name is first prop
-            name: hit.name,
-            // Custom latest prop
-            latest: hit.filename && hit.version ? 'https://cdnjs.cloudflare.com/ajax/libs/' + hit.name + '/' + hit.version + '/' + hit.filename : null,
-            // All other hit props
-            ...hit,
-        },
-        [
-            // Always send back name & latest
-            'name',
-            'latest',
-            // Send back whatever else was requested
-            ...requestedFields,
-        ],
-        requestedFields.includes('*'), // Send all if they have '*'
-    ));
+    }).map(hit => ({
+        // Always send back name & latest
+        name: hit.name,
+        latest: hit.filename && hit.version ? 'https://cdnjs.cloudflare.com/ajax/libs/' + hit.name + '/' + hit.version + '/' + hit.filename : null,
+        // Send back whatever else was requested, only send all if '*' explicitly included
+        ...filter(hit, requestedFields),
+    }));
 
     // If they want less data, allow that
     const limit = ctx.req.query('limit') && Number(ctx.req.query('limit'));

--- a/src/routes/library.js
+++ b/src/routes/library.js
@@ -3,7 +3,7 @@ import files from '../utils/files.js';
 import filter from '../utils/filter.js';
 import { library, libraryVersion, libraryVersionSri, libraryVersions } from '../utils/kvMetadata.js';
 import notFound from '../utils/notFound.js';
-import { queryArray } from '../utils/query.js';
+import { queryCheck } from '../utils/query.js';
 import respond from '../utils/respond.js';
 import sriForVersion from '../utils/sriForVersion.js';
 
@@ -38,26 +38,20 @@ const handleGetLibraryVersion = async ctx => {
     });
     if (!version) return notFound(ctx, 'Version');
 
-    // Build the object
-    const results = {
-        name: lib.name,
-        version: ctx.req.param('version'),
-        rawFiles: version,
-        files: version.filter(whitelisted),
-        sri: null,
-    };
-
     // Generate the initial filtered response (without SRI data)
-    const requestedFields = queryArray(ctx.req.queries('fields'));
+    const requestedFields = queryCheck(ctx.req.queries('fields'));
     const response = filter(
-        results,
+        {
+            name: lib.name,
+            version: ctx.req.param('version'),
+            rawFiles: version,
+            files: version.filter(whitelisted),
+        },
         requestedFields,
-        // If they requested no fields or '*', send them all
-        !requestedFields.length || requestedFields.includes('*'),
     );
 
     // Load SRI data if needed
-    if ('sri' in response) {
+    if (requestedFields('sri')) {
         // Get SRI for version
         const latestSriData = await libraryVersionSri(lib.name, ctx.req.param('version')).catch(() => {});
         response.sri = sriForVersion(lib.name, ctx.req.param('version'), version, latestSriData);
@@ -86,7 +80,7 @@ const handleGetLibrary = async ctx => {
     if (!lib) return notFound(ctx, 'Library');
 
     // Generate the initial filtered response (without SRI, versions or assets data)
-    const requestedFields = queryArray(ctx.req.queries('fields'));
+    const requestedFields = queryCheck(ctx.req.queries('fields'));
     const response = filter(
         {
             // Ensure name is first prop
@@ -96,20 +90,16 @@ const handleGetLibrary = async ctx => {
             sri: null,
             // All other lib props
             ...lib,
-            versions: null,
-            assets: null,
         },
         requestedFields,
-        // If they requested no fields or '*', send them all
-        !requestedFields.length || requestedFields.includes('*'),
     );
 
     // Get versions if needed
-    if ('versions' in response) response.versions = await libraryVersions(lib.name);
+    if (requestedFields('versions')) response.versions = await libraryVersions(lib.name);
 
     // Get assets if needed, inject SRI and do whitelist filtering
     // Returning assets for all versions is deprecated, we only return the latest version in the array
-    if ('assets' in response) {
+    if (requestedFields('assets')) {
         if (!lib.version) response.assets = [];
         else {
             // Fetch the assets for the version
@@ -129,7 +119,7 @@ const handleGetLibrary = async ctx => {
     }
 
     // Load SRI for latest if needed
-    if ('sri' in response) {
+    if (requestedFields('sri')) {
         if (lib.filename && lib.version) {
             // Handle if we've already fetched SRI
             if ('assets' in response) {

--- a/src/routes/stats.js
+++ b/src/routes/stats.js
@@ -1,7 +1,7 @@
 import cache from '../utils/cache.js';
 import filter from '../utils/filter.js';
 import { libraries } from '../utils/kvMetadata.js';
-import { queryArray } from '../utils/query.js';
+import { queryCheck } from '../utils/query.js';
 import respond from '../utils/respond.js';
 
 /**
@@ -12,14 +12,11 @@ import respond from '../utils/respond.js';
  */
 const handleGetStats = async ctx => {
     const libs = await libraries();
-    const requestedFields = queryArray(ctx.req.queries('fields'));
     const response = filter(
         {
             libraries: libs.length,
         },
-        requestedFields,
-        // If they requested no fields or '*', send them all
-        !requestedFields.length || requestedFields.includes('*'),
+        queryCheck(ctx.req.queries('fields')),
     );
 
     // Set a 6 hour life on this response

--- a/src/routes/whitelist.js
+++ b/src/routes/whitelist.js
@@ -1,7 +1,7 @@
 import cache from '../utils/cache.js';
 import files from '../utils/files.js';
 import filter from '../utils/filter.js';
-import { queryArray } from '../utils/query.js';
+import { queryCheck } from '../utils/query.js';
 import respond from '../utils/respond.js';
 
 /**
@@ -11,19 +11,13 @@ import respond from '../utils/respond.js';
  * @return {Response}
  */
 const handleGetWhitelist = ctx => {
-    // Build the object
-    const results = {
-        extensions: Object.keys(files),
-        categories: files,
-    };
-
     // Generate the filtered response
-    const requestedFields = queryArray(ctx.req.queries('fields'));
     const response = filter(
-        results,
-        requestedFields,
-        // If they requested no fields or '*', send them all
-        !requestedFields.length || requestedFields.includes('*'),
+        {
+            extensions: Object.keys(files),
+            categories: files,
+        },
+        queryCheck(ctx.req.queries('fields')),
     );
 
     // Set a 6 hour life on this response

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -1,38 +1,8 @@
 /**
- * Escape a string for rendering in HTML.
+ * Filter an object based on a provided filter function, returning a new object with only the allowed fields.
  *
- * @param {string} unsafe Unsafe string to escape.
- * @return {string}
- */
-const escape = unsafe => unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-
-/**
- * Generate an object containing the given fields, with values from the given source object or null.
- *
- * Field names will be escaped to be made safe for HTML.
- * This is a legacy behaviour for custom fields being requests.
- * No standard fields have characters that would require escaping.
- *
- * @param {Object} source Source object to extract safe fields from.
- * @param {string[]} fields Field names to include in generated object.
- * @param {boolean} [all=false] Generate object with all fields from source object (ignores fields param).
+ * @param {Object} source Source object to filter keys in.
+ * @param {function(string): boolean} filter Function to determine if a key should be included in the output.
  * @return {Object}
  */
-export default (source, fields, all = false) => {
-    if (all) {
-        return Object.entries(source).reduce((obj, [ key, value ]) => ({
-            ...obj,
-            [escape(key)]: value,
-        }), {});
-    }
-
-    return fields.reduce((obj, field) => ({
-        ...obj,
-        [escape(field)]: source[field] ?? null,
-    }), {});
-};
+export default (source, filter) => Object.fromEntries(Object.entries(source).filter(([ key ]) => filter(key)));

--- a/src/utils/query.js
+++ b/src/utils/query.js
@@ -16,3 +16,16 @@ export const queryArray = query => {
     }
     return [];
 };
+
+/**
+ * Get a function to check if a value is included in the query value.
+ *
+ * @param {string|string[]|undefined} query Query param value to extract values from.
+ * @param {boolean} [allByDefault=true] Whether to consider all values included if the query is empty.
+ * @return {function(string): boolean}
+ */
+export const queryCheck = (query, allByDefault = true) => {
+    const values = queryArray(query);
+    const all = values.includes('*') || (allByDefault && values.length === 0);
+    return value => all || values.includes(value.toLowerCase());
+};


### PR DESCRIPTION
## Type of Change

- **Utilities:** query + filter

## What issue does this relate to?

N/A

### What should this PR do?

Refactors how we do the filtering + query logic, relying on a check/filter method being passed into the filter util. This will assist #156, by allowing logic that conditionally adds a field to the response to not rely on a `null` value being passed in the initial filter call.

### What are the acceptance criteria?

Output is the same as production.