### PR TITLE
Mark KV metadata library author optional

### DIFF
--- a/src/utils/kvMetadata.schema.ts
+++ b/src/utils/kvMetadata.schema.ts
@@ -12,7 +12,7 @@ export const librarySchema = z.object({
     keywords: z.array(z.string()),
     homepage: z.string().optional(),
     license: z.string().optional(),
-    author: z.string(),
+    author: z.string().optional(),
     repository: z
         .object({
             type: z.string(),


### PR DESCRIPTION
## Type of Change

- **Utilities:** KV metadata schema

## What issue does this relate to?

https://cdnjs.sentry.io/issues/7319826796/?environment=production&project=6431561

### What should this PR do?

Marks `author` as optional, as certain libraries like `mathjax` do not have one present in the KV metadata.

### What are the acceptance criteria?

Mathjax can be loaded.