### PR TITLE
Mark KV metadata library filename optional

### DIFF
--- a/src/utils/kvMetadata.schema.ts
+++ b/src/utils/kvMetadata.schema.ts
@@ -6,10 +6,10 @@ export type Libraries = z.infer<typeof librariesSchema>;
 
 export const librarySchema = z.object({
     name: z.string(),
-    filename: z.string(),
-    version: z.string(),
     description: z.string(),
     keywords: z.array(z.string()),
+    version: z.string(),
+    filename: z.string().optional(),
     homepage: z.string().optional(),
     license: z.string().optional(),
     author: z.string().optional(),


### PR DESCRIPTION
## Type of Change

- **Utilities:** KV metadata schema

## What issue does this relate to?

https://cdnjs.sentry.io/issues/7320421287/?environment=production&project=6431561

### What should this PR do?

Marks `filename` as optional, as certain libraries like `hexo-theme-next` do not have one present in the KV metadata.

### What are the acceptance criteria?

`hexo-theme-next` can be loaded.