### PR TITLE
Mark KV metadata library repository optional

### DIFF
--- a/src/utils/kvMetadata.schema.ts
+++ b/src/utils/kvMetadata.schema.ts
@@ -18,7 +18,7 @@ export const librarySchema = z.object({
             type: z.string(),
             url: z.string(),
         })
-        .nullable(),
+        .optional(),
     autoupdate: z
         .union([
             z.object({


### PR DESCRIPTION
## Type of Change

- **Utilities:** KV metadata schema

## What issue does this relate to?

https://cdnjs.sentry.io/issues/7320421486/?environment=production&project=6431561

### What should this PR do?

Marks `repository` as optional, as certain libraries like `extjs` do not have one present in the KV metadata.

### What are the acceptance criteria?

`extjs` can be loaded.