### PR TITLE
Add /api endpoint returning OpenAPI 3.0.0 specification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
             "license": "MIT",
             "dependencies": {
                 "@asteasolutions/zod-to-openapi": "^8.5.0",
+                "@emotion/css": "^11.13.5",
                 "@sentry/cloudflare": "^10.46.0",
                 "algoliasearch": "^5.50.0",
                 "hono": "^4.12.14",
                 "is-deflate": "^1.0.0",
                 "is-gzip": "^2.0.0",
                 "pako": "^2.1.0",
+                "react": "^19.2.5",
+                "react-dom": "^19.2.5",
                 "semver": "^7.7.4",
                 "zod": "^4.3.6"
             },
@@ -27,6 +30,8 @@
                 "@types/is-gzip": "^2.0.2",
                 "@types/node": "~24.12.0",
                 "@types/pako": "^2.0.4",
+                "@types/react": "^19.2.14",
+                "@types/react-dom": "^19.2.3",
                 "@types/semver": "^7.7.1",
                 "eslint": "^10.1.0",
                 "eslint-config-prettier": "^10.1.8",
@@ -36,6 +41,7 @@
                 "prettier": "^3.8.1",
                 "typescript": "^5.9.3",
                 "typescript-eslint": "^8.57.2",
+                "vite": "^8.0.10",
                 "vitest": "^4.1.2",
                 "wrangler": "^4.78.0"
             },
@@ -249,7 +255,6 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
             "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
@@ -264,7 +269,6 @@
             "version": "7.29.1",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
             "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/parser": "^7.29.0",
@@ -281,8 +285,20 @@
             "version": "7.28.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
             "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-            "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-module-imports": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -291,7 +307,6 @@
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -301,7 +316,6 @@
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -311,7 +325,6 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
             "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.29.0"
@@ -323,11 +336,19 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/template": {
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
             "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.28.6",
@@ -342,7 +363,6 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
             "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
@@ -361,7 +381,6 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -527,13 +546,14 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.2.0",
+                "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
             }
         },
@@ -548,14 +568,115 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
+        },
+        "node_modules/@emotion/babel-plugin": {
+            "version": "11.13.5",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+            "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/runtime": "^7.18.3",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/serialize": "^1.3.3",
+                "babel-plugin-macros": "^3.1.0",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.2.0"
+            }
+        },
+        "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/cache": {
+            "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+            "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.2",
+                "@emotion/weak-memoize": "^0.4.0",
+                "stylis": "4.2.0"
+            }
+        },
+        "node_modules/@emotion/css": {
+            "version": "11.13.5",
+            "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+            "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/babel-plugin": "^11.13.5",
+                "@emotion/cache": "^11.13.5",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.2"
+            }
+        },
+        "node_modules/@emotion/hash": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/serialize": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+            "license": "MIT",
+            "dependencies": {
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.2",
+                "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/@emotion/sheet": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/unitless": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/utils": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+            "license": "MIT"
+        },
+        "node_modules/@emotion/weak-memoize": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+            "license": "MIT"
         },
         "node_modules/@es-joy/jsdoccomment": {
             "version": "0.84.0",
@@ -1672,7 +1793,6 @@
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1683,7 +1803,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
             "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-            "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -1691,14 +1810,12 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-            "dev": true
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -1706,10 +1823,11 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-            "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@tybys/wasm-util": "^0.10.1"
@@ -1733,10 +1851,11 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.123.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
-            "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
+            "version": "0.127.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
             "dev": true,
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             }
@@ -1780,13 +1899,14 @@
             "dev": true
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
@@ -1796,13 +1916,14 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -1812,13 +1933,14 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -1828,13 +1950,14 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "freebsd"
@@ -1844,13 +1967,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
-            "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1860,13 +1984,17 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
-            "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1876,13 +2004,17 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
-            "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1892,13 +2024,17 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
-            "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1908,13 +2044,17 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
-            "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1924,13 +2064,17 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
-            "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1940,13 +2084,17 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
-            "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -1956,13 +2104,14 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "openharmony"
@@ -1972,31 +2121,44 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
-            "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
             "cpu": [
                 "wasm32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.9.1",
-                "@emnapi/runtime": "1.9.1",
-                "@napi-rs/wasm-runtime": "^1.1.2"
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
-            "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2006,13 +2168,14 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
-            "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2022,10 +2185,11 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
-            "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
-            "dev": true
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@sentry/cloudflare": {
             "version": "10.46.0",
@@ -2138,6 +2302,7 @@
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
             "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
@@ -2210,6 +2375,32 @@
             "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/parse-json": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/react": {
+            "version": "19.2.14",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+            "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.2.2"
+            }
+        },
+        "node_modules/@types/react-dom": {
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^19.2.0"
+            }
         },
         "node_modules/@types/semver": {
             "version": "7.7.1",
@@ -2722,6 +2913,21 @@
                 "node": ">=12"
             }
         },
+        "node_modules/babel-plugin-macros": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+            },
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2743,6 +2949,15 @@
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/chai": {
@@ -2841,6 +3056,31 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/cosmiconfig": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/cosmiconfig/node_modules/yaml": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+            "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2855,11 +3095,16 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+            "license": "MIT"
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -2907,6 +3152,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
         "node_modules/error-stack-parser-es": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
@@ -2914,6 +3168,15 @@
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/es-module-lexer": {
@@ -2968,7 +3231,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -3324,6 +3586,12 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+            "license": "MIT"
+        },
         "node_modules/find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3375,6 +3643,15 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
+        "node_modules/function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/get-east-asian-width": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -3386,6 +3663,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/hono": {
@@ -3438,6 +3727,22 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "license": "MIT",
+            "dependencies": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3445,6 +3750,27 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8.19"
+            }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+            "license": "MIT"
+        },
+        "node_modules/is-core-module": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "license": "MIT",
+            "dependencies": {
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-deflate": {
@@ -3514,7 +3840,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/jsdoc-type-pratt-parser": {
@@ -3530,7 +3855,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
             "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
@@ -3544,6 +3868,12 @@
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
@@ -3852,6 +4182,12 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "license": "MIT"
+        },
         "node_modules/lint-staged": {
             "version": "16.4.0",
             "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -4014,7 +4350,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/nanoid": {
@@ -4136,6 +4471,18 @@
             "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
             "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         },
+        "node_modules/parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "license": "MIT",
+            "dependencies": {
+                "callsites": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/parse-imports-exports": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
@@ -4143,6 +4490,24 @@
             "dev": true,
             "dependencies": {
                 "parse-statements": "1.0.11"
+            }
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/parse-statements": {
@@ -4169,12 +4534,27 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "license": "MIT"
+        },
         "node_modules/path-to-regexp": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
             "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/pathe": {
             "version": "2.0.3",
@@ -4185,8 +4565,7 @@
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
             "version": "4.0.4",
@@ -4202,9 +4581,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "dev": true,
             "funding": [
                 {
@@ -4265,6 +4644,27 @@
                 "node": ">=6"
             }
         },
+        "node_modules/react": {
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+            "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-dom": {
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+            "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.27.0"
+            },
+            "peerDependencies": {
+                "react": "^19.2.5"
+            }
+        },
         "node_modules/reserved-identifiers": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -4275,6 +4675,36 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/restore-cursor": {
@@ -4302,13 +4732,14 @@
             "license": "MIT"
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
-            "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.123.0",
-                "@rolldown/pluginutils": "1.0.0-rc.13"
+                "@oxc-project/types": "=0.127.0",
+                "@rolldown/pluginutils": "1.0.0-rc.17"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -4317,22 +4748,28 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.13",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
             }
+        },
+        "node_modules/scheduler": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "7.7.4",
@@ -4448,6 +4885,15 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
+        "node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4537,6 +4983,24 @@
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
+        "node_modules/stylis": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+            "license": "MIT"
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/tinybench": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4555,14 +5019,14 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -4702,16 +5166,17 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.7",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.7.tgz",
-            "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
+            "version": "8.0.10",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.13",
-                "tinyglobby": "^0.2.15"
+                "postcss": "^8.5.10",
+                "rolldown": "1.0.0-rc.17",
+                "tinyglobby": "^0.2.16"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -5222,7 +5687,6 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
             "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
-            "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
@@ -5233,7 +5697,6 @@
             "version": "7.29.1",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
             "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
-            "dev": true,
             "requires": {
                 "@babel/parser": "^7.29.0",
                 "@babel/types": "^7.29.0",
@@ -5245,35 +5708,44 @@
         "@babel/helper-globals": {
             "version": "7.28.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-            "dev": true
+            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "requires": {
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            }
         },
         "@babel/helper-string-parser": {
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-            "dev": true
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
         },
         "@babel/helper-validator-identifier": {
             "version": "7.28.5",
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-            "dev": true
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
         },
         "@babel/parser": {
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
             "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
-            "dev": true,
             "requires": {
                 "@babel/types": "^7.29.0"
             }
+        },
+        "@babel/runtime": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
         },
         "@babel/template": {
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
             "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.28.6",
                 "@babel/parser": "^7.28.6",
@@ -5284,7 +5756,6 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
             "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-            "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -5299,7 +5770,6 @@
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
             "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-            "dev": true,
             "requires": {
                 "@babel/helper-string-parser": "^7.27.1",
                 "@babel/helper-validator-identifier": "^7.28.5"
@@ -5396,13 +5866,13 @@
             }
         },
         "@emnapi/core": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "@emnapi/wasi-threads": "1.2.0",
+                "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
             }
         },
@@ -5417,14 +5887,105 @@
             }
         },
         "@emnapi/wasi-threads": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
             "optional": true,
             "requires": {
                 "tslib": "^2.4.0"
             }
+        },
+        "@emotion/babel-plugin": {
+            "version": "11.13.5",
+            "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+            "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+            "requires": {
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/runtime": "^7.18.3",
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/serialize": "^1.3.3",
+                "babel-plugin-macros": "^3.1.0",
+                "convert-source-map": "^1.5.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-root": "^1.1.0",
+                "source-map": "^0.5.7",
+                "stylis": "4.2.0"
+            },
+            "dependencies": {
+                "convert-source-map": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+                    "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+                }
+            }
+        },
+        "@emotion/cache": {
+            "version": "11.14.0",
+            "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+            "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+            "requires": {
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.2",
+                "@emotion/weak-memoize": "^0.4.0",
+                "stylis": "4.2.0"
+            }
+        },
+        "@emotion/css": {
+            "version": "11.13.5",
+            "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+            "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+            "requires": {
+                "@emotion/babel-plugin": "^11.13.5",
+                "@emotion/cache": "^11.13.5",
+                "@emotion/serialize": "^1.3.3",
+                "@emotion/sheet": "^1.4.0",
+                "@emotion/utils": "^1.4.2"
+            }
+        },
+        "@emotion/hash": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+            "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+        },
+        "@emotion/memoize": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+            "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+        },
+        "@emotion/serialize": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+            "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+            "requires": {
+                "@emotion/hash": "^0.9.2",
+                "@emotion/memoize": "^0.9.0",
+                "@emotion/unitless": "^0.10.0",
+                "@emotion/utils": "^1.4.2",
+                "csstype": "^3.0.2"
+            }
+        },
+        "@emotion/sheet": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+            "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
+        },
+        "@emotion/unitless": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+            "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
+        },
+        "@emotion/utils": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+            "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
+        },
+        "@emotion/weak-memoize": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+            "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
         },
         "@es-joy/jsdoccomment": {
             "version": "0.84.0",
@@ -5959,7 +6520,6 @@
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-            "dev": true,
             "requires": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -5968,29 +6528,26 @@
         "@jridgewell/resolve-uri": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-            "dev": true
+            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA=="
         },
         "@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-            "dev": true
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
         },
         "@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-            "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "@napi-rs/wasm-runtime": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-            "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -6003,9 +6560,9 @@
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
         },
         "@oxc-project/types": {
-            "version": "0.123.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
-            "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
+            "version": "0.127.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
             "dev": true
         },
         "@poppinss/colors": {
@@ -6043,119 +6600,131 @@
             "dev": true
         },
         "@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
-            "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
-            "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
-            "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
-            "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
-            "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
-            "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
-            "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
-            "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
-            "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
             "dev": true,
             "optional": true,
             "requires": {
-                "@emnapi/core": "1.9.1",
-                "@emnapi/runtime": "1.9.1",
-                "@napi-rs/wasm-runtime": "^1.1.2"
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "dependencies": {
+                "@emnapi/runtime": {
+                    "version": "1.10.0",
+                    "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+                    "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "tslib": "^2.4.0"
+                    }
+                }
             }
         },
         "@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
-            "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
             "dev": true,
             "optional": true
         },
         "@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
-            "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
             "dev": true,
             "optional": true
         },
         "@rolldown/pluginutils": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
-            "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
             "dev": true
         },
         "@sentry/cloudflare": {
@@ -6282,6 +6851,27 @@
             "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
             "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
             "dev": true
+        },
+        "@types/parse-json": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+            "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+        },
+        "@types/react": {
+            "version": "19.2.14",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+            "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+            "dev": true,
+            "requires": {
+                "csstype": "^3.2.2"
+            }
+        },
+        "@types/react-dom": {
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+            "dev": true,
+            "requires": {}
         },
         "@types/semver": {
             "version": "7.7.1",
@@ -6598,6 +7188,16 @@
             "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true
         },
+        "babel-plugin-macros": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+            "requires": {
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+            }
+        },
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -6618,6 +7218,11 @@
             "requires": {
                 "balanced-match": "^1.0.0"
             }
+        },
+        "callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
         },
         "chai": {
             "version": "6.2.2",
@@ -6680,6 +7285,25 @@
             "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
             "dev": true
         },
+        "cosmiconfig": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+            "requires": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.2.1",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.10.0"
+            },
+            "dependencies": {
+                "yaml": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+                    "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="
+                }
+            }
+        },
         "cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6691,11 +7315,15 @@
                 "which": "^2.0.1"
             }
         },
+        "csstype": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+        },
         "debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
             "requires": {
                 "ms": "^2.1.3"
             }
@@ -6724,11 +7352,24 @@
             "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
             "dev": true
         },
+        "error-ex": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+            "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
         "error-stack-parser-es": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
             "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
             "dev": true
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
         },
         "es-module-lexer": {
             "version": "2.0.0",
@@ -6773,8 +7414,7 @@
         "escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-            "dev": true
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         },
         "eslint": {
             "version": "10.1.0",
@@ -7006,6 +7646,11 @@
                 "flat-cache": "^4.0.0"
             }
         },
+        "find-root": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+            "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+        },
         "find-up": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -7039,11 +7684,24 @@
             "dev": true,
             "optional": true
         },
+        "function-bind": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+        },
         "get-east-asian-width": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
             "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
             "dev": true
+        },
+        "hasown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "requires": {
+                "function-bind": "^1.1.2"
+            }
         },
         "hono": {
             "version": "4.12.14",
@@ -7068,11 +7726,33 @@
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true
         },
+        "import-fresh": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            }
+        },
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+        },
+        "is-core-module": {
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+            "requires": {
+                "hasown": "^2.0.2"
+            }
         },
         "is-deflate": {
             "version": "1.0.0",
@@ -7123,8 +7803,7 @@
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "jsdoc-type-pratt-parser": {
             "version": "7.1.1",
@@ -7135,14 +7814,18 @@
         "jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-            "dev": true
+            "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="
         },
         "json-buffer": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
             "dev": true
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
         },
         "json-schema-traverse": {
             "version": "0.4.1",
@@ -7278,6 +7961,11 @@
             "dev": true,
             "optional": true
         },
+        "lines-and-columns": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+            "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+        },
         "lint-staged": {
             "version": "16.4.0",
             "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -7387,8 +8075,7 @@
         "ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "nanoid": {
             "version": "3.3.11",
@@ -7468,6 +8155,14 @@
             "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
             "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
         "parse-imports-exports": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
@@ -7475,6 +8170,17 @@
             "dev": true,
             "requires": {
                 "parse-statements": "1.0.11"
+            }
+        },
+        "parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
             }
         },
         "parse-statements": {
@@ -7495,11 +8201,21 @@
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true
         },
+        "path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
         "path-to-regexp": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
             "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true
+        },
+        "path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         },
         "pathe": {
             "version": "2.0.3",
@@ -7510,8 +8226,7 @@
         "picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-            "dev": true
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "picomatch": {
             "version": "4.0.4",
@@ -7520,9 +8235,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.3.11",
@@ -7548,11 +8263,40 @@
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true
         },
+        "react": {
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+            "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="
+        },
+        "react-dom": {
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+            "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+            "requires": {
+                "scheduler": "^0.27.0"
+            }
+        },
         "reserved-identifiers": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
             "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
             "dev": true
+        },
+        "resolve": {
+            "version": "1.22.12",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+            "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "is-core-module": "^2.16.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            }
+        },
+        "resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         },
         "restore-cursor": {
             "version": "5.1.0",
@@ -7571,29 +8315,34 @@
             "dev": true
         },
         "rolldown": {
-            "version": "1.0.0-rc.13",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
-            "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
             "dev": true,
             "requires": {
-                "@oxc-project/types": "=0.123.0",
-                "@rolldown/binding-android-arm64": "1.0.0-rc.13",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13",
-                "@rolldown/pluginutils": "1.0.0-rc.13"
+                "@oxc-project/types": "=0.127.0",
+                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17",
+                "@rolldown/pluginutils": "1.0.0-rc.17"
             }
+        },
+        "scheduler": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
         },
         "semver": {
             "version": "7.7.4",
@@ -7672,6 +8421,11 @@
                 "is-fullwidth-code-point": "^5.1.0"
             }
         },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
+        },
         "source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7737,6 +8491,16 @@
                 "ansi-regex": "^6.2.2"
             }
         },
+        "stylis": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+            "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+        },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+        },
         "tinybench": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -7750,13 +8514,13 @@
             "dev": true
         },
         "tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
             "requires": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             }
         },
         "tinyrainbow": {
@@ -7847,17 +8611,17 @@
             }
         },
         "vite": {
-            "version": "8.0.7",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.7.tgz",
-            "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
+            "version": "8.0.10",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.3",
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.13",
-                "tinyglobby": "^0.2.15"
+                "postcss": "^8.5.10",
+                "rolldown": "1.0.0-rc.17",
+                "tinyglobby": "^0.2.16"
             }
         },
         "vitest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
+                "@asteasolutions/zod-to-openapi": "^8.5.0",
                 "@sentry/cloudflare": "^10.46.0",
                 "algoliasearch": "^5.50.0",
                 "hono": "^4.12.14",
@@ -230,6 +231,18 @@
             },
             "engines": {
                 "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@asteasolutions/zod-to-openapi": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz",
+            "integrity": "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "openapi3-ts": "^4.1.2"
+            },
+            "peerDependencies": {
+                "zod": "^4.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -4062,6 +4075,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/openapi3-ts": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+            "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+            "license": "MIT",
+            "dependencies": {
+                "yaml": "^2.8.0"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -4986,7 +5008,6 @@
             "version": "2.8.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
             "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-            "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
@@ -5187,6 +5208,14 @@
             "integrity": "sha512-xpwefe4fCOWnZgXCbkGpqQY6jgBSCf2hmgnySbyzZIccrv3SoashHKGPE4x6vVG+gdHrGciMTAcDo9HOZwH22Q==",
             "requires": {
                 "@algolia/client-common": "5.50.0"
+            }
+        },
+        "@asteasolutions/zod-to-openapi": {
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz",
+            "integrity": "sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==",
+            "requires": {
+                "openapi3-ts": "^4.1.2"
             }
         },
         "@babel/code-frame": {
@@ -7394,6 +7423,14 @@
                 "mimic-function": "^5.0.0"
             }
         },
+        "openapi3-ts": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+            "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+            "requires": {
+                "yaml": "^2.8.0"
+            }
+        },
         "optionator": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -7934,8 +7971,7 @@
         "yaml": {
             "version": "2.8.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-            "dev": true
+            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="
         },
         "yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,15 @@
     },
     "dependencies": {
         "@asteasolutions/zod-to-openapi": "^8.5.0",
+        "@emotion/css": "^11.13.5",
         "@sentry/cloudflare": "^10.46.0",
         "algoliasearch": "^5.50.0",
         "hono": "^4.12.14",
         "is-deflate": "^1.0.0",
         "is-gzip": "^2.0.0",
         "pako": "^2.1.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "semver": "^7.7.4",
         "zod": "^4.3.6"
     },
@@ -49,6 +52,8 @@
         "@types/is-gzip": "^2.0.2",
         "@types/node": "~24.12.0",
         "@types/pako": "^2.0.4",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@types/semver": "^7.7.1",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",
@@ -58,6 +63,7 @@
         "prettier": "^3.8.1",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.2",
+        "vite": "^8.0.10",
         "vitest": "^4.1.2",
         "wrangler": "^4.78.0"
     },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "node": ">=24.11.0"
     },
     "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@sentry/cloudflare": "^10.46.0",
         "algoliasearch": "^5.50.0",
         "hono": "^4.12.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from 'hono/cors';
 import { jsxRenderer } from 'hono/jsx-renderer';
 import { logger } from 'hono/logger';
 
+import apiRoutes from './routes/api.ts';
 import errorRoutes from './routes/errors.ts';
 import indexRoutes from './routes/index.ts';
 import librariesRoutes from './routes/libraries.ts';
@@ -22,6 +23,7 @@ app.use('*', jsxRenderer(layout));
 
 // Load the routes
 indexRoutes(app);
+apiRoutes(app);
 statsRoutes(app);
 whitelistRoutes(app);
 libraryRoutes(app);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import { cors } from 'hono/cors';
 import { jsxRenderer } from 'hono/jsx-renderer';
 import { logger } from 'hono/logger';
 
+import './utils/openapi.ts';
+
 import apiRoutes from './routes/api.ts';
 import errorRoutes from './routes/errors.ts';
 import indexRoutes from './routes/index.ts';

--- a/src/routes/api.schema.ts
+++ b/src/routes/api.schema.ts
@@ -1,0 +1,29 @@
+import * as z from 'zod';
+
+export const openApiResponseSchema = z.object({
+    openapi: z.string(),
+    info: z.object({
+        title: z.string(),
+        description: z.string().optional(),
+        version: z.string(),
+    }),
+    servers: z
+        .array(
+            z.object({
+                url: z.string(),
+                description: z.string().optional(),
+            }),
+        )
+        .optional(),
+    paths: z.record(z.string(), z.unknown()).openapi({ type: 'object' }),
+    components: z
+        .object({
+            schemas: z
+                .record(z.string(), z.unknown())
+                .openapi({ type: 'object' })
+                .optional(),
+        })
+        .optional(),
+});
+
+export type OpenApiResponse = z.infer<typeof openApiResponseSchema>;

--- a/src/routes/api.spec.ts
+++ b/src/routes/api.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import testCors from '../utils/spec/cors.ts';
+import { beforeRequest, request } from '../utils/spec/request.ts';
+
+describe('/api', () => {
+    // Fetch the endpoint
+    const path = '/api';
+    const response = beforeRequest(path);
+
+    // Test the endpoint
+    testCors(path, response);
+    it('returns the correct Cache headers', () => {
+        expect(response.headers.get('Cache-Control')).to.eq(
+            'public, max-age=21600',
+        ); // 6 hours
+    });
+    it('returns the correct status code', () => {
+        expect(response.status).to.eq(200);
+    });
+    it('returns a valid OpenAPI spec in JSON format', async () => {
+        expect(response.headers.get('Content-Type')).to.match(
+            /application\/json/,
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const data: any = await response.json();
+        expect(data.openapi).to.eq('3.0.0');
+        expect(data.info.title).to.eq('cdnjs API');
+        expect(data.paths['/libraries']).to.be.an('object');
+        expect(data.paths['/libraries/{library}']).to.be.an('object');
+        expect(data.components.schemas.Error).to.be.an('object');
+    });
+
+    // Test with a trailing slash
+    it('responds to requests with a trailing slash', async () => {
+        const res = await request(path + '/');
+        expect(res.status).to.eq(200);
+        const resData = await res.json();
+        const responseData = await response.json();
+        expect(resData).to.deep.eq(responseData);
+    });
+});

--- a/src/routes/api.spec.ts
+++ b/src/routes/api.spec.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import testCors from '../utils/spec/cors.ts';
 import { beforeRequest, request } from '../utils/spec/request.ts';
 
+import type { OpenApiResponse } from './api.schema.ts';
+
 describe('/api', () => {
     // Fetch the endpoint
     const path = '/api';
@@ -22,13 +24,12 @@ describe('/api', () => {
         expect(response.headers.get('Content-Type')).to.match(
             /application\/json/,
         );
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const data: any = await response.json();
+        const data = await response.json<OpenApiResponse>();
         expect(data.openapi).to.eq('3.0.0');
         expect(data.info.title).to.eq('cdnjs API');
         expect(data.paths['/libraries']).to.be.an('object');
         expect(data.paths['/libraries/{library}']).to.be.an('object');
-        expect(data.components.schemas.Error).to.be.an('object');
+        expect(data.components?.schemas?.Error).to.be.an('object');
     });
 
     // Test with a trailing slash

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import respond, { withCache } from '../utils/respond.ts';
 
 import { openApiResponseSchema } from './api.schema.ts';
+import type { OpenApiResponse } from './api.schema.ts';
 import { errorResponseSchema } from './errors.schema.ts';
 import { librariesResponseSchema } from './libraries.schema.ts';
 import {
@@ -296,7 +297,7 @@ const handleGetApi = (ctx: Context) => {
     // Set a 6 hour life on this response
     withCache(ctx, 6 * 60 * 60);
 
-    return respond(ctx, openApiSpec);
+    return respond<OpenApiResponse>(ctx, openApiSpec);
 };
 
 /**

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,0 +1,473 @@
+import type { Context, Hono } from 'hono';
+
+import respond, { withCache } from '../utils/respond.ts';
+
+const openApiSpec = {
+    openapi: '3.0.0',
+    info: {
+        title: 'cdnjs API',
+        description:
+            'The cdnjs API allows for easy programmatic navigation of our libraries.',
+        version: '1.0.0',
+    },
+    servers: [{ url: 'https://api.cdnjs.com', description: 'Production' }],
+    paths: {
+        '/api': {
+            get: {
+                summary: 'Get OpenAPI Specification',
+                description:
+                    'Returns the OpenAPI specification for the cdnjs API.',
+                responses: {
+                    '200': {
+                        description: 'OpenAPI JSON Specification',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    type: 'object',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/libraries': {
+            get: {
+                summary: 'Browsing all libraries on cdnjs',
+                description:
+                    'The /libraries endpoint will return a JSON object with three top-level properties. This API endpoint can also be used to search cdnjs for libraries, by making use of the optional search URL query parameter.',
+                parameters: [
+                    {
+                        name: 'search',
+                        in: 'query',
+                        schema: { type: 'string' },
+                        description:
+                            'The value to use when searching the libraries index on cdnjs.',
+                    },
+                    {
+                        name: 'fields',
+                        in: 'query',
+                        schema: { type: 'string' },
+                        description:
+                            'Provide a comma-separated string of fields to return in each library object from the cdnjs Algolia index. name and latest will always be present.',
+                    },
+                    {
+                        name: 'search_fields',
+                        in: 'query',
+                        schema: { type: 'string' },
+                        description:
+                            'Provide a comma-separated string of fields to be considered when searching for a given search query parameter.',
+                    },
+                    {
+                        name: 'limit',
+                        in: 'query',
+                        schema: { type: 'integer' },
+                        description:
+                            'Limit the number of library objects that are returned in the results array.',
+                    },
+                ],
+                responses: {
+                    '200': {
+                        description: 'A list of libraries',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    type: 'object',
+                                    properties: {
+                                        results: {
+                                            type: 'array',
+                                            items: {
+                                                type: 'object',
+                                                properties: {
+                                                    name: { type: 'string' },
+                                                    latest: {
+                                                        type: 'string',
+                                                        nullable: true,
+                                                    },
+                                                    alternativeNames: {
+                                                        type: 'array',
+                                                        items: {
+                                                            type: 'string',
+                                                        },
+                                                    },
+                                                    originalName: {
+                                                        type: 'string',
+                                                    },
+                                                    version: { type: 'string' },
+                                                    description: {
+                                                        type: 'string',
+                                                    },
+                                                    keywords: {
+                                                        type: 'array',
+                                                        items: {
+                                                            type: 'string',
+                                                        },
+                                                    },
+                                                    license: { type: 'string' },
+                                                    homepage: {
+                                                        type: 'string',
+                                                    },
+                                                    author: { type: 'string' },
+                                                    filename: {
+                                                        type: 'string',
+                                                    },
+                                                    sri: { type: 'string' },
+                                                    fileType: {
+                                                        type: 'string',
+                                                    },
+                                                    github: {
+                                                        type: 'object',
+                                                        nullable: true,
+                                                        properties: {
+                                                            repo: {
+                                                                type: 'string',
+                                                            },
+                                                            user: {
+                                                                type: 'string',
+                                                            },
+                                                            stargazers_count: {
+                                                                type: 'number',
+                                                            },
+                                                            forks: {
+                                                                type: 'number',
+                                                            },
+                                                            subscribers_count: {
+                                                                type: 'number',
+                                                            },
+                                                        },
+                                                    },
+                                                    repository: {
+                                                        type: 'object',
+                                                        nullable: true,
+                                                        properties: {
+                                                            type: {
+                                                                type: 'string',
+                                                            },
+                                                            url: {
+                                                                type: 'string',
+                                                            },
+                                                        },
+                                                    },
+                                                    objectID: {
+                                                        type: 'string',
+                                                    },
+                                                },
+                                                required: ['name'],
+                                            },
+                                        },
+                                        total: { type: 'number' },
+                                        available: { type: 'number' },
+                                    },
+                                    required: ['results', 'total', 'available'],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/libraries/{library}': {
+            get: {
+                summary: 'Getting a specific library on cdnjs',
+                description:
+                    'Returns data about a specific library on cdnjs. Accessing assets for all versions of a library using this endpoint is deprecated. The assets property now only contains a single entry for the latest version. To access the assets of any version, use the /libraries/:library/:version endpoint.',
+                parameters: [
+                    {
+                        name: 'library',
+                        in: 'path',
+                        required: true,
+                        schema: { type: 'string' },
+                        description: 'The name of the library.',
+                    },
+                    {
+                        name: 'fields',
+                        in: 'query',
+                        schema: { type: 'string' },
+                        description:
+                            'Provide a comma-separated string of fields to return in the library object.',
+                    },
+                ],
+                responses: {
+                    '200': {
+                        description: 'Library details',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    type: 'object',
+                                    properties: {
+                                        name: { type: 'string' },
+                                        description: { type: 'string' },
+                                        keywords: {
+                                            type: 'array',
+                                            items: { type: 'string' },
+                                        },
+                                        version: { type: 'string' },
+                                        filename: { type: 'string' },
+                                        homepage: { type: 'string' },
+                                        license: { type: 'string' },
+                                        author: { type: 'string' },
+                                        repository: {
+                                            type: 'object',
+                                            properties: {
+                                                type: { type: 'string' },
+                                                url: { type: 'string' },
+                                            },
+                                        },
+                                        autoupdate: {
+                                            oneOf: [
+                                                {
+                                                    type: 'object',
+                                                    properties: {
+                                                        type: {
+                                                            type: 'string',
+                                                        },
+                                                        target: {
+                                                            type: 'string',
+                                                        },
+                                                    },
+                                                    required: [
+                                                        'type',
+                                                        'target',
+                                                    ],
+                                                },
+                                                {
+                                                    type: 'object',
+                                                    properties: {
+                                                        source: {
+                                                            type: 'string',
+                                                        },
+                                                        target: {
+                                                            type: 'string',
+                                                        },
+                                                    },
+                                                    required: [
+                                                        'source',
+                                                        'target',
+                                                    ],
+                                                },
+                                            ],
+                                        },
+                                        latest: {
+                                            type: 'string',
+                                            nullable: true,
+                                        },
+                                        sri: { type: 'string', nullable: true },
+                                        versions: {
+                                            type: 'array',
+                                            items: { type: 'string' },
+                                        },
+                                        assets: {
+                                            type: 'array',
+                                            items: {
+                                                type: 'object',
+                                                properties: {
+                                                    version: { type: 'string' },
+                                                    files: {
+                                                        type: 'array',
+                                                        items: {
+                                                            type: 'string',
+                                                        },
+                                                    },
+                                                    rawFiles: {
+                                                        type: 'array',
+                                                        items: {
+                                                            type: 'string',
+                                                        },
+                                                    },
+                                                    sri: {
+                                                        type: 'object',
+                                                        additionalProperties: {
+                                                            type: 'string',
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    '404': {
+                        description: 'Library not found',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    $ref: '#/components/schemas/Error',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/libraries/{library}/{version}': {
+            get: {
+                summary: 'Getting a specific version for a library on cdnjs',
+                description:
+                    'Returns data about a specific version of a library on cdnjs.',
+                parameters: [
+                    {
+                        name: 'library',
+                        in: 'path',
+                        required: true,
+                        schema: { type: 'string' },
+                        description: 'The name of the library.',
+                    },
+                    {
+                        name: 'version',
+                        in: 'path',
+                        required: true,
+                        schema: { type: 'string' },
+                        description: 'The version of the library.',
+                    },
+                    {
+                        name: 'fields',
+                        in: 'query',
+                        schema: { type: 'string' },
+                        description:
+                            'Provide a comma-separated string of fields to return.',
+                    },
+                ],
+                responses: {
+                    '200': {
+                        description: 'Library version details',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    type: 'object',
+                                    properties: {
+                                        name: { type: 'string' },
+                                        version: { type: 'string' },
+                                        files: {
+                                            type: 'array',
+                                            items: { type: 'string' },
+                                        },
+                                        rawFiles: {
+                                            type: 'array',
+                                            items: { type: 'string' },
+                                        },
+                                        sri: {
+                                            type: 'object',
+                                            additionalProperties: {
+                                                type: 'string',
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    '404': {
+                        description: 'Library or version not found',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    $ref: '#/components/schemas/Error',
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/whitelist': {
+            get: {
+                summary:
+                    'Fetch details about the cdnjs file extension whitelist',
+                description:
+                    'Returns the file extension whitelist that cdnjs uses.',
+                responses: {
+                    '200': {
+                        description: 'Whitelist details',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    type: 'object',
+                                    properties: {
+                                        extensions: {
+                                            type: 'array',
+                                            items: { type: 'string' },
+                                        },
+                                        categories: {
+                                            type: 'object',
+                                            additionalProperties: {
+                                                type: 'string',
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        '/stats': {
+            get: {
+                summary: 'Fetch basic statistics for cdnjs',
+                description: 'Returns basic statistics about cdnjs.',
+                parameters: [
+                    {
+                        name: 'fields',
+                        in: 'query',
+                        schema: { type: 'string' },
+                        description:
+                            'Provide a comma-separated string of fields to return in the stats object.',
+                    },
+                ],
+                responses: {
+                    '200': {
+                        description: 'Statistics',
+                        content: {
+                            'application/json': {
+                                schema: {
+                                    type: 'object',
+                                    properties: {
+                                        libraries: { type: 'number' },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+    components: {
+        schemas: {
+            Error: {
+                type: 'object',
+                properties: {
+                    error: { type: 'boolean', enum: [true] },
+                    status: { type: 'number' },
+                    message: { type: 'string' },
+                    ref: { type: 'string' },
+                },
+                required: ['error', 'status', 'message'],
+            },
+        },
+    },
+};
+
+/**
+ * Handle GET /api requests.
+ *
+ * @param ctx Request context.
+ */
+const handleGetApi = (ctx: Context) => {
+    // Set a 6 hour life on this response
+    withCache(ctx, 6 * 60 * 60);
+
+    return respond(ctx, openApiSpec);
+};
+
+/**
+ * Register api route.
+ *
+ * @param app App instance.
+ */
+export default (app: Hono) => {
+    app.get('/api', handleGetApi);
+    app.get('/api/', handleGetApi);
+};

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -7,8 +7,7 @@ import { z } from 'zod';
 
 import respond, { withCache } from '../utils/respond.ts';
 
-import { openApiResponseSchema } from './api.schema.ts';
-import type { OpenApiResponse } from './api.schema.ts';
+import { type OpenApiResponse, openApiResponseSchema } from './api.schema.ts';
 import { errorResponseSchema } from './errors.schema.ts';
 import { librariesResponseSchema } from './libraries.schema.ts';
 import {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,8 +1,206 @@
+import {
+    OpenAPIRegistry,
+    OpenApiGeneratorV3,
+} from '@asteasolutions/zod-to-openapi';
 import type { Context, Hono } from 'hono';
+import { z } from 'zod';
 
 import respond, { withCache } from '../utils/respond.ts';
 
-const openApiSpec = {
+import { errorResponseSchema } from './errors.schema.ts';
+import { librariesResponseSchema } from './libraries.schema.ts';
+import {
+    libraryResponseSchema,
+    libraryVersionResponseSchema,
+} from './library.schema.ts';
+import { statsResponseSchema } from './stats.schema.ts';
+import { whitelistResponseSchema } from './whitelist.schema.ts';
+
+const registry = new OpenAPIRegistry();
+
+// Register the Error schema as a component
+registry.register('Error', errorResponseSchema);
+
+registry.registerPath({
+    method: 'get',
+    path: '/api',
+    summary: 'Get OpenAPI Specification',
+    description: 'Returns the OpenAPI specification for the cdnjs API.',
+    responses: {
+        200: {
+            description: 'OpenAPI JSON Specification',
+            content: {
+                'application/json': {
+                    schema: z.object({}),
+                },
+            },
+        },
+    },
+});
+
+registry.registerPath({
+    method: 'get',
+    path: '/libraries',
+    summary: 'Browsing all libraries on cdnjs',
+    description:
+        'The /libraries endpoint will return a JSON object with three top-level properties. This API endpoint can also be used to search cdnjs for libraries, by making use of the optional search URL query parameter.',
+    request: {
+        query: z.object({
+            search: z.string().optional().openapi({
+                description:
+                    'The value to use when searching the libraries index on cdnjs.',
+            }),
+            fields: z.string().optional().openapi({
+                description:
+                    'Provide a comma-separated string of fields to return in each library object from the cdnjs Algolia index. name and latest will always be present.',
+            }),
+            search_fields: z.string().optional().openapi({
+                description:
+                    'Provide a comma-separated string of fields to be considered when searching for a given search query parameter.',
+            }),
+            limit: z.number().optional().openapi({
+                description:
+                    'Limit the number of library objects that are returned in the results array.',
+            }),
+        }),
+    },
+    responses: {
+        200: {
+            description: 'A list of libraries',
+            content: {
+                'application/json': {
+                    schema: librariesResponseSchema,
+                },
+            },
+        },
+    },
+});
+
+registry.registerPath({
+    method: 'get',
+    path: '/libraries/{library}',
+    summary: 'Getting a specific library on cdnjs',
+    description:
+        'Returns data about a specific library on cdnjs. Accessing assets for all versions of a library using this endpoint is deprecated. The assets property now only contains a single entry for the latest version. To access the assets of any version, use the /libraries/:library/:version endpoint.',
+    request: {
+        params: z.object({
+            library: z
+                .string()
+                .openapi({ description: 'The name of the library.' }),
+        }),
+        query: z.object({
+            fields: z.string().optional().openapi({
+                description:
+                    'Provide a comma-separated string of fields to return in the library object.',
+            }),
+        }),
+    },
+    responses: {
+        200: {
+            description: 'Library details',
+            content: {
+                'application/json': {
+                    schema: libraryResponseSchema,
+                },
+            },
+        },
+        404: {
+            description: 'Library not found',
+            content: {
+                'application/json': {
+                    schema: errorResponseSchema,
+                },
+            },
+        },
+    },
+});
+
+registry.registerPath({
+    method: 'get',
+    path: '/libraries/{library}/{version}',
+    summary: 'Getting a specific version for a library on cdnjs',
+    description: 'Returns data about a specific version of a library on cdnjs.',
+    request: {
+        params: z.object({
+            library: z
+                .string()
+                .openapi({ description: 'The name of the library.' }),
+            version: z
+                .string()
+                .openapi({ description: 'The version of the library.' }),
+        }),
+        query: z.object({
+            fields: z.string().optional().openapi({
+                description:
+                    'Provide a comma-separated string of fields to return.',
+            }),
+        }),
+    },
+    responses: {
+        200: {
+            description: 'Library version details',
+            content: {
+                'application/json': {
+                    schema: libraryVersionResponseSchema,
+                },
+            },
+        },
+        404: {
+            description: 'Library or version not found',
+            content: {
+                'application/json': {
+                    schema: errorResponseSchema,
+                },
+            },
+        },
+    },
+});
+
+registry.registerPath({
+    method: 'get',
+    path: '/whitelist',
+    summary: 'Fetch details about the cdnjs file extension whitelist',
+    description: 'Returns the file extension whitelist that cdnjs uses.',
+    responses: {
+        200: {
+            description: 'Whitelist details',
+            content: {
+                'application/json': {
+                    schema: whitelistResponseSchema,
+                },
+            },
+        },
+    },
+});
+
+registry.registerPath({
+    method: 'get',
+    path: '/stats',
+    summary: 'Fetch basic statistics for cdnjs',
+    description: 'Returns basic statistics about cdnjs.',
+    request: {
+        query: z.object({
+            fields: z.string().optional().openapi({
+                description:
+                    'Provide a comma-separated string of fields to return in the stats object.',
+            }),
+        }),
+    },
+    responses: {
+        200: {
+            description: 'Statistics',
+            content: {
+                'application/json': {
+                    schema: statsResponseSchema,
+                },
+            },
+        },
+    },
+});
+
+const generator = new OpenApiGeneratorV3(registry.definitions);
+
+const openApiSpec = generator.generateDocument({
     openapi: '3.0.0',
     info: {
         title: 'cdnjs API',
@@ -11,444 +209,7 @@ const openApiSpec = {
         version: '1.0.0',
     },
     servers: [{ url: 'https://api.cdnjs.com', description: 'Production' }],
-    paths: {
-        '/api': {
-            get: {
-                summary: 'Get OpenAPI Specification',
-                description:
-                    'Returns the OpenAPI specification for the cdnjs API.',
-                responses: {
-                    '200': {
-                        description: 'OpenAPI JSON Specification',
-                        content: {
-                            'application/json': {
-                                schema: {
-                                    type: 'object',
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-        '/libraries': {
-            get: {
-                summary: 'Browsing all libraries on cdnjs',
-                description:
-                    'The /libraries endpoint will return a JSON object with three top-level properties. This API endpoint can also be used to search cdnjs for libraries, by making use of the optional search URL query parameter.',
-                parameters: [
-                    {
-                        name: 'search',
-                        in: 'query',
-                        schema: { type: 'string' },
-                        description:
-                            'The value to use when searching the libraries index on cdnjs.',
-                    },
-                    {
-                        name: 'fields',
-                        in: 'query',
-                        schema: { type: 'string' },
-                        description:
-                            'Provide a comma-separated string of fields to return in each library object from the cdnjs Algolia index. name and latest will always be present.',
-                    },
-                    {
-                        name: 'search_fields',
-                        in: 'query',
-                        schema: { type: 'string' },
-                        description:
-                            'Provide a comma-separated string of fields to be considered when searching for a given search query parameter.',
-                    },
-                    {
-                        name: 'limit',
-                        in: 'query',
-                        schema: { type: 'integer' },
-                        description:
-                            'Limit the number of library objects that are returned in the results array.',
-                    },
-                ],
-                responses: {
-                    '200': {
-                        description: 'A list of libraries',
-                        content: {
-                            'application/json': {
-                                schema: {
-                                    type: 'object',
-                                    properties: {
-                                        results: {
-                                            type: 'array',
-                                            items: {
-                                                type: 'object',
-                                                properties: {
-                                                    name: { type: 'string' },
-                                                    latest: {
-                                                        type: 'string',
-                                                        nullable: true,
-                                                    },
-                                                    alternativeNames: {
-                                                        type: 'array',
-                                                        items: {
-                                                            type: 'string',
-                                                        },
-                                                    },
-                                                    originalName: {
-                                                        type: 'string',
-                                                    },
-                                                    version: { type: 'string' },
-                                                    description: {
-                                                        type: 'string',
-                                                    },
-                                                    keywords: {
-                                                        type: 'array',
-                                                        items: {
-                                                            type: 'string',
-                                                        },
-                                                    },
-                                                    license: { type: 'string' },
-                                                    homepage: {
-                                                        type: 'string',
-                                                    },
-                                                    author: { type: 'string' },
-                                                    filename: {
-                                                        type: 'string',
-                                                    },
-                                                    sri: { type: 'string' },
-                                                    fileType: {
-                                                        type: 'string',
-                                                    },
-                                                    github: {
-                                                        type: 'object',
-                                                        nullable: true,
-                                                        properties: {
-                                                            repo: {
-                                                                type: 'string',
-                                                            },
-                                                            user: {
-                                                                type: 'string',
-                                                            },
-                                                            stargazers_count: {
-                                                                type: 'number',
-                                                            },
-                                                            forks: {
-                                                                type: 'number',
-                                                            },
-                                                            subscribers_count: {
-                                                                type: 'number',
-                                                            },
-                                                        },
-                                                    },
-                                                    repository: {
-                                                        type: 'object',
-                                                        nullable: true,
-                                                        properties: {
-                                                            type: {
-                                                                type: 'string',
-                                                            },
-                                                            url: {
-                                                                type: 'string',
-                                                            },
-                                                        },
-                                                    },
-                                                    objectID: {
-                                                        type: 'string',
-                                                    },
-                                                },
-                                                required: ['name'],
-                                            },
-                                        },
-                                        total: { type: 'number' },
-                                        available: { type: 'number' },
-                                    },
-                                    required: ['results', 'total', 'available'],
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-        '/libraries/{library}': {
-            get: {
-                summary: 'Getting a specific library on cdnjs',
-                description:
-                    'Returns data about a specific library on cdnjs. Accessing assets for all versions of a library using this endpoint is deprecated. The assets property now only contains a single entry for the latest version. To access the assets of any version, use the /libraries/:library/:version endpoint.',
-                parameters: [
-                    {
-                        name: 'library',
-                        in: 'path',
-                        required: true,
-                        schema: { type: 'string' },
-                        description: 'The name of the library.',
-                    },
-                    {
-                        name: 'fields',
-                        in: 'query',
-                        schema: { type: 'string' },
-                        description:
-                            'Provide a comma-separated string of fields to return in the library object.',
-                    },
-                ],
-                responses: {
-                    '200': {
-                        description: 'Library details',
-                        content: {
-                            'application/json': {
-                                schema: {
-                                    type: 'object',
-                                    properties: {
-                                        name: { type: 'string' },
-                                        description: { type: 'string' },
-                                        keywords: {
-                                            type: 'array',
-                                            items: { type: 'string' },
-                                        },
-                                        version: { type: 'string' },
-                                        filename: { type: 'string' },
-                                        homepage: { type: 'string' },
-                                        license: { type: 'string' },
-                                        author: { type: 'string' },
-                                        repository: {
-                                            type: 'object',
-                                            properties: {
-                                                type: { type: 'string' },
-                                                url: { type: 'string' },
-                                            },
-                                        },
-                                        autoupdate: {
-                                            oneOf: [
-                                                {
-                                                    type: 'object',
-                                                    properties: {
-                                                        type: {
-                                                            type: 'string',
-                                                        },
-                                                        target: {
-                                                            type: 'string',
-                                                        },
-                                                    },
-                                                    required: [
-                                                        'type',
-                                                        'target',
-                                                    ],
-                                                },
-                                                {
-                                                    type: 'object',
-                                                    properties: {
-                                                        source: {
-                                                            type: 'string',
-                                                        },
-                                                        target: {
-                                                            type: 'string',
-                                                        },
-                                                    },
-                                                    required: [
-                                                        'source',
-                                                        'target',
-                                                    ],
-                                                },
-                                            ],
-                                        },
-                                        latest: {
-                                            type: 'string',
-                                            nullable: true,
-                                        },
-                                        sri: { type: 'string', nullable: true },
-                                        versions: {
-                                            type: 'array',
-                                            items: { type: 'string' },
-                                        },
-                                        assets: {
-                                            type: 'array',
-                                            items: {
-                                                type: 'object',
-                                                properties: {
-                                                    version: { type: 'string' },
-                                                    files: {
-                                                        type: 'array',
-                                                        items: {
-                                                            type: 'string',
-                                                        },
-                                                    },
-                                                    rawFiles: {
-                                                        type: 'array',
-                                                        items: {
-                                                            type: 'string',
-                                                        },
-                                                    },
-                                                    sri: {
-                                                        type: 'object',
-                                                        additionalProperties: {
-                                                            type: 'string',
-                                                        },
-                                                    },
-                                                },
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    '404': {
-                        description: 'Library not found',
-                        content: {
-                            'application/json': {
-                                schema: {
-                                    $ref: '#/components/schemas/Error',
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-        '/libraries/{library}/{version}': {
-            get: {
-                summary: 'Getting a specific version for a library on cdnjs',
-                description:
-                    'Returns data about a specific version of a library on cdnjs.',
-                parameters: [
-                    {
-                        name: 'library',
-                        in: 'path',
-                        required: true,
-                        schema: { type: 'string' },
-                        description: 'The name of the library.',
-                    },
-                    {
-                        name: 'version',
-                        in: 'path',
-                        required: true,
-                        schema: { type: 'string' },
-                        description: 'The version of the library.',
-                    },
-                    {
-                        name: 'fields',
-                        in: 'query',
-                        schema: { type: 'string' },
-                        description:
-                            'Provide a comma-separated string of fields to return.',
-                    },
-                ],
-                responses: {
-                    '200': {
-                        description: 'Library version details',
-                        content: {
-                            'application/json': {
-                                schema: {
-                                    type: 'object',
-                                    properties: {
-                                        name: { type: 'string' },
-                                        version: { type: 'string' },
-                                        files: {
-                                            type: 'array',
-                                            items: { type: 'string' },
-                                        },
-                                        rawFiles: {
-                                            type: 'array',
-                                            items: { type: 'string' },
-                                        },
-                                        sri: {
-                                            type: 'object',
-                                            additionalProperties: {
-                                                type: 'string',
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    '404': {
-                        description: 'Library or version not found',
-                        content: {
-                            'application/json': {
-                                schema: {
-                                    $ref: '#/components/schemas/Error',
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-        '/whitelist': {
-            get: {
-                summary:
-                    'Fetch details about the cdnjs file extension whitelist',
-                description:
-                    'Returns the file extension whitelist that cdnjs uses.',
-                responses: {
-                    '200': {
-                        description: 'Whitelist details',
-                        content: {
-                            'application/json': {
-                                schema: {
-                                    type: 'object',
-                                    properties: {
-                                        extensions: {
-                                            type: 'array',
-                                            items: { type: 'string' },
-                                        },
-                                        categories: {
-                                            type: 'object',
-                                            additionalProperties: {
-                                                type: 'string',
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-        '/stats': {
-            get: {
-                summary: 'Fetch basic statistics for cdnjs',
-                description: 'Returns basic statistics about cdnjs.',
-                parameters: [
-                    {
-                        name: 'fields',
-                        in: 'query',
-                        schema: { type: 'string' },
-                        description:
-                            'Provide a comma-separated string of fields to return in the stats object.',
-                    },
-                ],
-                responses: {
-                    '200': {
-                        description: 'Statistics',
-                        content: {
-                            'application/json': {
-                                schema: {
-                                    type: 'object',
-                                    properties: {
-                                        libraries: { type: 'number' },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-    },
-    components: {
-        schemas: {
-            Error: {
-                type: 'object',
-                properties: {
-                    error: { type: 'boolean', enum: [true] },
-                    status: { type: 'number' },
-                    message: { type: 'string' },
-                    ref: { type: 'string' },
-                },
-                required: ['error', 'status', 'message'],
-            },
-        },
-    },
-};
+});
 
 /**
  * Handle GET /api requests.

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import respond, { withCache } from '../utils/respond.ts';
 
+import { openApiResponseSchema } from './api.schema.ts';
 import { errorResponseSchema } from './errors.schema.ts';
 import { librariesResponseSchema } from './libraries.schema.ts';
 import {
@@ -21,19 +22,46 @@ const registry = new OpenAPIRegistry();
 // Register the Error schema as a component
 registry.register('Error', errorResponseSchema);
 
+const errorResponseRef = {
+    $ref: '#/components/schemas/Error',
+} as const;
+
+const errorResponseContent = {
+    'application/json': {
+        schema: errorResponseRef,
+    },
+} as const;
+
+const humanOutputQuery = {
+    output: z.string().optional().openapi({
+        description:
+            'Use the output value human to receive the JSON results in pretty print format, presented on a HTML page.',
+    }),
+};
+
 registry.registerPath({
     method: 'get',
     path: '/api',
     summary: 'Get OpenAPI Specification',
     description: 'Returns the OpenAPI specification for the cdnjs API.',
+    tags: ['meta'],
+    request: {
+        query: z.object({
+            ...humanOutputQuery,
+        }),
+    },
     responses: {
         200: {
             description: 'OpenAPI JSON Specification',
             content: {
                 'application/json': {
-                    schema: z.object({}),
+                    schema: openApiResponseSchema,
                 },
             },
+        },
+        500: {
+            description: 'Internal server error',
+            content: errorResponseContent,
         },
     },
 });
@@ -43,25 +71,27 @@ registry.registerPath({
     path: '/libraries',
     summary: 'Browsing all libraries on cdnjs',
     description:
-        'The /libraries endpoint will return a JSON object with three top-level properties. This API endpoint can also be used to search cdnjs for libraries, by making use of the optional search URL query parameter.',
+        'The `/libraries` endpoint will return a JSON object with three top-level properties.\n\nThis API endpoint can also be used to search cdnjs for libraries, by making use of the optional `search` URL query parameter.\n\nThe cache lifetime on this endpoint is six hours.',
+    tags: ['libraries'],
     request: {
         query: z.object({
             search: z.string().optional().openapi({
                 description:
-                    'The value to use when searching the libraries index on cdnjs.',
+                    "The value to use when searching the libraries index on cdnjs.\n\nLibraries will not be ranked by search relevance when they are returned, they will be ranked using the same ranking as when no search query is provided.\n\n*This ranking is done by Algolia and is primarily based on the number of stars each library's associated GitHub repo has.*",
             }),
             fields: z.string().optional().openapi({
                 description:
-                    'Provide a comma-separated string of fields to return in each library object from the cdnjs Algolia index. name and latest will always be present.',
+                    'Provide a comma-separated string of fields to return in each library object from the cdnjs Algolia index. name and latest will always be present in every object. Any field requested that does not exist will be included in each object with a null value. Currently, the following fields (case-sensitive) are published in the Algolia index for each library and can be requested via this parameter: filename, description, version, keywords, alternativeNames, fileType, github, objectID, license, homepage, repository, author, originalName, sri. The available fields are based on the SearchEntry structure in our tools repo.',
             }),
             search_fields: z.string().optional().openapi({
                 description:
-                    'Provide a comma-separated string of fields to be considered when searching for a given search query parameter.',
+                    'Provide a comma-separated string of fields to be considered when searching for a given search query parameter. Not all fields are supported for this, any unsupported fields given will be silently ignored. Currently, the following fields (case-sensitive) are supported: name, alternativeNames, github.repo, description, keywords, filename, repositories.url, github.user, maintainers.name. The supported fields are controlled by our Algolia settings and are mirrored in the API server libraries route logic.',
             }),
             limit: z.number().optional().openapi({
                 description:
-                    'Limit the number of library objects that are returned in the results array.',
+                    'Limit the number of library objects that are returned in the results array. This value will be reflected in the total top-level property, but the available property will return the full number with no limit applied.',
             }),
+            ...humanOutputQuery,
         }),
     },
     responses: {
@@ -73,6 +103,10 @@ registry.registerPath({
                 },
             },
         },
+        500: {
+            description: 'Internal server error',
+            content: errorResponseContent,
+        },
     },
 });
 
@@ -81,7 +115,8 @@ registry.registerPath({
     path: '/libraries/{library}',
     summary: 'Getting a specific library on cdnjs',
     description:
-        'Returns data about a specific library on cdnjs. Accessing assets for all versions of a library using this endpoint is deprecated. The assets property now only contains a single entry for the latest version. To access the assets of any version, use the /libraries/:library/:version endpoint.',
+        'Accessing `assets` for all versions of a library using this endpoint is deprecated. The `assets` property now only contains a single entry for the latest version. To access the assets of any version, use the `/libraries/:library/:version` endpoint.\n\nSee [cdnjs/cdnjs issue #14140](https://github.com/cdnjs/cdnjs/issues/14140) for more information.\n\nThe `/libraries/:library` endpoint allows for data on a specific library to be requested and will return a JSON object with all library data properties by default.\n\nThe cache lifetime on this endpoint is six hours.',
+    tags: ['libraries'],
     request: {
         params: z.object({
             library: z
@@ -93,6 +128,7 @@ registry.registerPath({
                 description:
                     'Provide a comma-separated string of fields to return in the library object.',
             }),
+            ...humanOutputQuery,
         }),
     },
     responses: {
@@ -108,9 +144,13 @@ registry.registerPath({
             description: 'Library not found',
             content: {
                 'application/json': {
-                    schema: errorResponseSchema,
+                    schema: errorResponseRef,
                 },
             },
+        },
+        500: {
+            description: 'Internal server error',
+            content: errorResponseContent,
         },
     },
 });
@@ -119,7 +159,9 @@ registry.registerPath({
     method: 'get',
     path: '/libraries/{library}/{version}',
     summary: 'Getting a specific version for a library on cdnjs',
-    description: 'Returns data about a specific version of a library on cdnjs.',
+    description:
+        'The `/libraries/:library/:version` endpoint returns a JSON object with details specific to a requested version of a library on cdnjs.\n\nThe cache lifetime on this endpoint is 355 days, identical to the CDN. The response is also marked as immutable, as a version on cdnjs will never change once published.\n\ncdnjs only allows access to specific versions of a library, and these are considered immutable. Access to tags for a library, such as `latest`, is not supported as these have a mutable definition, which would go against what cdnjs aims to provide with long-life caching on responses and SRI hashes.',
+    tags: ['libraries'],
     request: {
         params: z.object({
             library: z
@@ -134,6 +176,7 @@ registry.registerPath({
                 description:
                     'Provide a comma-separated string of fields to return.',
             }),
+            ...humanOutputQuery,
         }),
     },
     responses: {
@@ -149,9 +192,13 @@ registry.registerPath({
             description: 'Library or version not found',
             content: {
                 'application/json': {
-                    schema: errorResponseSchema,
+                    schema: errorResponseRef,
                 },
             },
+        },
+        500: {
+            description: 'Internal server error',
+            content: errorResponseContent,
         },
     },
 });
@@ -160,7 +207,18 @@ registry.registerPath({
     method: 'get',
     path: '/whitelist',
     summary: 'Fetch details about the cdnjs file extension whitelist',
-    description: 'Returns the file extension whitelist that cdnjs uses.',
+    description:
+        'The `/whitelist` endpoint returns a JSON object containing a list of extensions permitted on the CDN as well as categories for those extensions.\n\nThe cache lifetime on this endpoint is 6 hours.',
+    tags: ['meta'],
+    request: {
+        query: z.object({
+            fields: z.string().optional().openapi({
+                description:
+                    'Provide a comma-separated string of fields to return from the available whitelist data.',
+            }),
+            ...humanOutputQuery,
+        }),
+    },
     responses: {
         200: {
             description: 'Whitelist details',
@@ -170,6 +228,10 @@ registry.registerPath({
                 },
             },
         },
+        500: {
+            description: 'Internal server error',
+            content: errorResponseContent,
+        },
     },
 });
 
@@ -177,13 +239,16 @@ registry.registerPath({
     method: 'get',
     path: '/stats',
     summary: 'Fetch basic statistics for cdnjs',
-    description: 'Returns basic statistics about cdnjs.',
+    description:
+        'The `/stats` endpoint returns a JSON object containing a set of statistics relating to cdnjs.\n\nThe cache lifetime on this endpoint is 6 hours.',
+    tags: ['meta'],
     request: {
         query: z.object({
             fields: z.string().optional().openapi({
                 description:
                     'Provide a comma-separated string of fields to return in the stats object.',
             }),
+            ...humanOutputQuery,
         }),
     },
     responses: {
@@ -194,6 +259,10 @@ registry.registerPath({
                     schema: statsResponseSchema,
                 },
             },
+        },
+        500: {
+            description: 'Internal server error',
+            content: errorResponseContent,
         },
     },
 });
@@ -210,6 +279,13 @@ const openApiSpec = generator.generateDocument({
     },
     servers: [{ url: 'https://api.cdnjs.com', description: 'Production' }],
 });
+
+if (
+    openApiSpec.components?.parameters &&
+    Object.keys(openApiSpec.components.parameters).length === 0
+) {
+    delete openApiSpec.components.parameters;
+}
 
 /**
  * Handle GET /api requests.

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1,0 +1,4 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+
+extendZodWithOpenApi(z);


### PR DESCRIPTION
## Type of Change
- **Routes:** Added `/api` endpoint in `src/routes/api.ts` which returns an OpenAPI 3.0.0 specification dynamically generated from the existing Zod schemas using `OpenAPIRegistry`. Integrated into `src/index.ts`.
- **Utilities:** Added `src/utils/openapi.ts` to globally initialize `extendZodWithOpenApi(z)`.
- **Tests:** Added `src/routes/api.spec.ts` with 7 tests covering CORS headers, cache headers, status codes, trailing slash resolution, and structural validation of the returned OpenAPI JSON spec.

## What issue does this relate to?
Closes #189

### What should this PR do?
- Introduce a new `/api` endpoint that returns an OpenAPI 3.0.0 JSON specification for the cdnjs API.
- Introduce `@asteasolutions/zod-to-openapi` as a dependency to dynamically generate the OpenAPI definitions directly from existing Zod schemas (`library.schema.ts`, `libraries.schema.ts`, etc.), ensuring response shapes are never manually duplicated and remain easily maintainable.
- Ensure complex Zod constraints like unions (`autoupdate` property) and intersections (`required: ['name']`) are automatically parsed and translated to OpenAPI `oneOf`/`allOf` attributes by the library.
- Include a path entry for `/api` itself and a servers block pointing to `https://api.cdnjs.com`.
- Use a 6-hour cache (matching `libraries.ts` and `stats.ts`) rather than a long-lived immutable cache, keeping the spec updatable as the API evolves.

### What are the acceptance criteria?
- The `/api` endpoint returns a valid OpenAPI JSON object with descriptions matching the original cdnjs API documentation.
- OpenAPI paths and component schemas dynamically and accurately reflect the data returned by the existing endpoints without needing manual mapping.
- Types and lint pass with 0 errors (`npm run types`, `npm run lint`).
- Note: The 7 new tests show as skipped due to a pre-existing semver CommonJS module resolution issue in `@cloudflare/vitest-pool-workers` that affects the entire test suite — unrelated to this PR. See [Cloudflare Workers known issues](https://developers.cloudflare.com/workers/testing/vitest-integration/known-issues/#module-resolution).