### PR TITLE
Require a generic for respond util

### DIFF
--- a/src/routes/errors.ts
+++ b/src/routes/errors.ts
@@ -59,11 +59,11 @@ export default (app: Hono) => {
 
         // Send the error response
         ctx.status(500);
-        return respond(ctx, {
+        return respond<ErrorResponse>(ctx, {
             error: true,
             status: 500,
             message: err.message,
             ref: sentry,
-        } satisfies ErrorResponse);
+        });
     });
 };

--- a/src/routes/libraries.ts
+++ b/src/routes/libraries.ts
@@ -46,11 +46,11 @@ const handleGetLibraries = async (ctx: Context) => {
     withCache(ctx, 6 * 60 * 60);
 
     // Send the response
-    return respond(ctx, {
+    return respond<LibrariesResponse>(ctx, {
         results: trimmed,
         total: trimmed.length, // Total results we're sending back
         available: response.length, // Total number available without trimming
-    } satisfies LibrariesResponse);
+    });
 };
 
 /**

--- a/src/routes/library.ts
+++ b/src/routes/library.ts
@@ -124,7 +124,7 @@ const handleGetLibraryVersion = async (ctx: Context) => {
     withCache(ctx, 355 * 24 * 60 * 60, true);
 
     // Send the response
-    return respond(ctx, response);
+    return respond<LibraryVersionResponse>(ctx, response);
 };
 
 /**
@@ -235,7 +235,7 @@ const handleGetLibrary = async (ctx: Context) => {
     withCache(ctx, 6 * 60 * 60);
 
     // Send the response
-    return respond(ctx, response);
+    return respond<LibraryResponse>(ctx, response);
 };
 
 /**

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -25,7 +25,7 @@ const handleGetStats = async (ctx: Context) => {
     withCache(ctx, 6 * 60 * 60);
 
     // Send the response
-    return respond(ctx, response);
+    return respond<StatsResponse>(ctx, response);
 };
 
 /**

--- a/src/routes/whitelist.ts
+++ b/src/routes/whitelist.ts
@@ -26,7 +26,7 @@ const handleGetWhitelist = (ctx: Context) => {
     withCache(ctx, 6 * 60 * 60);
 
     // Send the response
-    return respond(ctx, response);
+    return respond<WhitelistResponse>(ctx, response);
 };
 
 /**

--- a/src/utils/respond.ts
+++ b/src/utils/respond.ts
@@ -36,7 +36,7 @@ export const withCache = (ctx: Context, age: number, immutable = false) => {
  * @param ctx Request context.
  * @param data Data to be included in the response.
  */
-const respond = (ctx: Context, data: unknown) => {
+const respond = <T = never>(ctx: Context, data: NoInfer<T>) => {
     if (ctx.req.query('output') === 'human') {
         event('human-output', { ctx });
         ctx.header('X-Robots-Tag', 'noindex');
@@ -60,9 +60,9 @@ export const notFound = (ctx: Context, resource: string) => {
 
     // Send the error response
     ctx.status(404);
-    return respond(ctx, {
+    return respond<ErrorResponse>(ctx, {
         error: true,
         status: 404,
         message: `${resource} not found`,
-    } satisfies ErrorResponse);
+    });
 };


### PR DESCRIPTION
## Type of Change

- **Utilities:** `respond`

## What issue does this relate to?

N/A

### What should this PR do?

Introduces a further bit of type-safety to the responses by explicitly requiring a generic be passed into `respond` for the response data shape.

### What are the acceptance criteria?

Type-checking passes.
