### PR TITLE
Generate client island entry points with hashed file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ which will be bundled by Vite from [`src/utils/jsx/islands/`](src/utils/jsx/isla
 The client hydration entrypoints are built automatically for each island into `dist-client/`, via
 the [`[build]` hook in `wrangler.toml`](wrangler.toml), and served as static assets by the worker.
 
-Client components use the `withIsland` wrapper during server-side rendering to associate them with
+Client components use the `createIsland` wrapper during server-side rendering to associate them with
 their serialize props and their client hydration entrypoint:
 
 ```tsx
 import { useState } from 'react';
 
-import withIsland from '../island.tsx';
+import createIsland from '../island.tsx';
 
 const Counter = ({ label, button }: { label: string; button: string }) => {
     const [count, setCount] = useState(0);
@@ -64,11 +64,11 @@ const Counter = ({ label, button }: { label: string; button: string }) => {
     );
 };
 
-export default withIsland(Counter, 'counter.tsx');
+export default createIsland(Counter, 'counter.tsx');
 ```
 
 The components can then be used throughout the server-rendered JSX, and will be automatically
-hydrated on the client, with the Vite build automatically stripping the `withIsland` wrapper to
+hydrated on the client, with the Vite build automatically stripping the `createIsland` wrapper to
 access the underlying component for the client bundles.
 
 ## Testing and More

--- a/src/utils/jsx/island.tsx
+++ b/src/utils/jsx/island.tsx
@@ -105,7 +105,7 @@ const Island = <T extends object>({
  * @param component Island component.
  * @param file Island file name (used to infer client entrypoint).
  */
-const withIsland =
+const createIsland =
     <T extends object>(
         component: ComponentType<T>,
         file: `${string}.tsx`,
@@ -118,4 +118,4 @@ const withIsland =
         />
     );
 
-export default withIsland;
+export default createIsland;

--- a/src/utils/jsx/island.tsx
+++ b/src/utils/jsx/island.tsx
@@ -1,4 +1,44 @@
-import { type ComponentType, useId } from 'react';
+import { env } from 'cloudflare:workers';
+import { type ComponentType, createContext, useContext, useId } from 'react';
+import * as z from 'zod';
+
+const manifestSchema = z.record(
+    z.string(),
+    z.object({
+        file: z.string(),
+    }),
+);
+
+type Manifest = z.infer<typeof manifestSchema>;
+
+const IslandContext = createContext<{ manifest: Manifest } | null>(null);
+
+/**
+ * Loads the entry manifest for client islands and returns a context provider to supply it to server-rendered islands.
+ */
+export const createIslandProvider = async () => {
+    const response = await env.ASSETS.fetch(
+        'https://assets.local/islands/manifest.json',
+    );
+    if (!response.ok) {
+        throw new Error(
+            `Failed to load island manifest: ${response.status} ${response.statusText}`,
+        );
+    }
+    const manifest = manifestSchema.parse(await response.json());
+
+    /**
+     * Server helper for providing the entry manifest to server-rendered client islands via context.
+     *
+     * @param props Wrapper props.
+     * @param props.children Children to be rendered within the provider to access the context.
+     */
+    return ({ children }: { children: React.ReactNode }) => (
+        <IslandContext.Provider value={{ manifest }}>
+            {children}
+        </IslandContext.Provider>
+    );
+};
 
 const serializeProps = (props: object) =>
     JSON.stringify(props)
@@ -26,6 +66,18 @@ const Island = <T extends object>({
     const instanceId = useId().replaceAll(':', '');
     const propsScriptId = `island-props-${name}-${instanceId}`;
 
+    const { manifest } = useContext(IslandContext) ?? {};
+    if (!manifest) {
+        throw new Error(
+            'Island component must be rendered within an IslandProvider',
+        );
+    }
+
+    const entry = manifest[`virtual:island-entry:${name}`];
+    if (!entry) {
+        throw new Error(`Missing manifest entry for island "${name}"`);
+    }
+
     return (
         <>
             <div data-island={name} data-island-props={propsScriptId}>
@@ -40,7 +92,7 @@ const Island = <T extends object>({
                 }}
             />
 
-            <script type="module" src={`/islands/${name}.js`} />
+            <script type="module" src={`/${entry.file}`} />
         </>
     );
 };

--- a/src/utils/jsx/islands/status.tsx
+++ b/src/utils/jsx/islands/status.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import * as z from 'zod/mini';
 
 import theme from '../../theme.ts';
-import withIsland from '../island.tsx';
+import createIsland from '../island.tsx';
 
 const indicatorSchema = z.literal(['none', 'minor', 'major', 'critical']);
 type Indicator = z.infer<typeof indicatorSchema>;
@@ -78,4 +78,4 @@ const Status = () => {
     );
 };
 
-export default withIsland(Status, 'status.tsx');
+export default createIsland(Status, 'status.tsx');

--- a/src/utils/respond.ts
+++ b/src/utils/respond.ts
@@ -7,6 +7,7 @@ import { renderToString } from 'react-dom/server';
 import type { ErrorResponse } from '../routes/errors.schema.ts';
 
 import event from './event.ts';
+import { createIslandProvider } from './jsx/island.tsx';
 import Json from './jsx/json.tsx';
 import Layout from './jsx/layout.tsx';
 
@@ -77,13 +78,22 @@ export const withCache = (ctx: Context, age: number, immutable = false) => {
  * @param ctx Request context.
  * @param data Data to be included in the response.
  */
-const respond = <T = never>(ctx: Context, data: NoInfer<T>) => {
+const respond = async <T = never>(ctx: Context, data: NoInfer<T>) => {
     if (ctx.req.query('output') === 'human') {
         event('human-output', { ctx });
         ctx.header('X-Robots-Tag', 'noindex');
 
+        const Provider = await createIslandProvider();
         const body = renderToString(
-            createElement(Layout, null, createElement(Json, { json: data })),
+            createElement(
+                Provider,
+                null,
+                createElement(
+                    Layout,
+                    null,
+                    createElement(Json, { json: data }),
+                ),
+            ),
         );
         const styles = getCriticalEmotionCss(body);
 

--- a/vite.client.config.ts
+++ b/vite.client.config.ts
@@ -81,10 +81,15 @@ export default defineConfig({
                     );
                 }
 
-                return code.replace(
-                    declaration.fullMatch,
-                    `export default ${declaration.componentReference};`,
-                );
+                return code
+                    .replace(
+                        declaration.fullMatch,
+                        `export default ${declaration.componentReference};`,
+                    )
+                    .replace(
+                        /import\s+(?:withIsland\s+)?from\s+['"]\.\.\/island\.tsx['"];?\n?/g,
+                        '',
+                    );
             },
             // Generate one virtual hydration entry per island source file.
             load(id) {
@@ -114,6 +119,7 @@ export default defineConfig({
         outDir: outputDirectory,
         emptyOutDir: true,
         sourcemap: true,
+        manifest: 'islands/manifest.json',
         rollupOptions: {
             // Generate a separate client entry for each island, based on the file name.
             input: Object.fromEntries(
@@ -124,7 +130,7 @@ export default defineConfig({
             ),
             output: {
                 // Place island chunks in a directory that doesn't conflict with the API.
-                entryFileNames: 'islands/[name].js',
+                entryFileNames: 'islands/[name]-[hash].js',
                 chunkFileNames: 'islands/chunks/[name]-[hash].js',
                 assetFileNames: 'islands/assets/[name]-[hash][extname]',
                 // Share the core React hydration code across all islands as a separate chunk.

--- a/vite.client.config.ts
+++ b/vite.client.config.ts
@@ -30,9 +30,9 @@ const islandEntryByPath = new Map(
     islandEntries.map((entry) => [entry.path, entry]),
 );
 
-const parseWithIslandDeclaration = (source: string) => {
+const parseCreateIslandDeclaration = (source: string) => {
     const match = source.match(
-        /export\s+default\s+withIsland\(\s*([^,]+)\s*,\s*['"]([^'"]+)['"]\s*\)\s*;?/,
+        /export\s+default\s+createIsland\(\s*([^,]+)\s*,\s*['"]([^'"]+)['"]\s*\)\s*;?/,
     );
     if (!match || !match[1] || !match[2]) {
         return null;
@@ -64,10 +64,10 @@ export default defineConfig({
                     return null;
                 }
 
-                const declaration = parseWithIslandDeclaration(code);
+                const declaration = parseCreateIslandDeclaration(code);
                 if (!declaration) {
                     throw new Error(
-                        `Island file "${id}" must export its default component via withIsland(..., '<file>.tsx').`,
+                        `Island file "${id}" must export its default component via createIsland(..., '<file>.tsx').`,
                     );
                 }
 
@@ -75,7 +75,7 @@ export default defineConfig({
                     throw new Error(
                         [
                             `Island filename mismatch for "${entry.path}".`,
-                            `withIsland declares "${declaration.declaredFile}", but the actual file builds as "${entry.name}.tsx".`,
+                            `createIsland declares "${declaration.declaredFile}", but the actual file builds as "${entry.name}.tsx".`,
                             'Keep these names aligned so SSR script tags match generated client bundles.',
                         ].join(' '),
                     );
@@ -87,7 +87,7 @@ export default defineConfig({
                         `export default ${declaration.componentReference};`,
                     )
                     .replace(
-                        /import\s+(?:withIsland\s+)?from\s+['"]\.\.\/island\.tsx['"];?\n?/g,
+                        /import\s+(?:createIsland\s+)?from\s+['"]\.\.\/island\.tsx['"];?\n?/g,
                         '',
                     );
             },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,4 @@
 import { cloudflareTest } from '@cloudflare/vitest-pool-workers';
-import { mkdirSync } from 'node:fs';
 import { stripVTControlCharacters } from 'node:util';
 import { defineConfig } from 'vitest/config';
 
@@ -14,10 +13,9 @@ console.log = (...args) => {
     return originalLog(...args);
 };
 
-mkdirSync('dist-client', { recursive: true });
-
 export default defineConfig({
     test: {
+        globalSetup: './vitest.setup.ts',
         silent: 'passed-only',
         reporters: [
             'tree',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,8 @@
+import { execSync } from 'node:child_process';
+
+export const setup = () => {
+    console.log('Building client islands...');
+    execSync('npx vite build --config vite.client.config.ts', {
+        stdio: 'inherit',
+    });
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,6 +11,7 @@ watch_dir = "src"
 
 [assets]
 directory = "./dist-client"
+binding = "ASSETS"
 
 [observability.logs]
 enabled = true


### PR DESCRIPTION
## Type of Change

- **Utilities:** JSX Islands

## What issue does this relate to?

cc #200 #190

### What should this PR do?

Updates the client islands implementation to generate hashed files, to avoid stale file issues when loading in a browser.

### What are the acceptance criteria?

Client islands continue to function in human output.