### PR TITLE
Skip client build for external tests

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,12 @@
 import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
 
 export const setup = () => {
+    if (process.env.VITEST_EXTERNAL_API_URL) {
+        mkdirSync('dist-client', { recursive: true });
+        return;
+    }
+
     console.log('Building client islands...');
     execSync('npx vite build --config vite.client.config.ts', {
         stdio: 'inherit',


### PR DESCRIPTION
## Type of Change

- **Tests:** Setup

## What issue does this relate to?

cc #201

### What should this PR do?

We don't need to generate the full client build when running tests against an external deployment, just the directory needs to be stubbed.

### What are the acceptance criteria?

Tests continue to run when using an external URL w/o dist-client being present locally.