### PR TITLE
Add Swagger UI for OpenAPI human output

### DIFF
--- a/imports.d.ts
+++ b/imports.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+    const content: string;
+    export default content;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "react": "^19.2.5",
                 "react-dom": "^19.2.5",
                 "semver": "^7.7.4",
+                "swagger-ui-react": "^5.32.5",
                 "zod": "^4.3.6"
             },
             "devDependencies": {
@@ -33,6 +34,7 @@
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.2.3",
                 "@types/semver": "^7.7.1",
+                "@types/swagger-ui-react": "^5.18.0",
                 "eslint": "^10.2.1",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-jsdoc": "^62.9.0",
@@ -341,6 +343,18 @@
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
             "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/runtime-corejs3": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+            "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+            "license": "MIT",
+            "dependencies": {
+                "core-js-pure": "^3.48.0"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2163,6 +2177,13 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@scarf/scarf": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+            "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/@sentry/cloudflare": {
             "version": "10.50.0",
             "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.50.0.tgz",
@@ -2227,6 +2248,701 @@
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@swagger-api/apidom-ast": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.0.tgz",
+            "integrity": "sha512-poLd6eNipLCFCrxjZD+E9E0Z85CLfFzueNiVcYj86rwMp2OszYsTzZS2jz82yR/usNCjXCpkQ2xEXWSmDhefPg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "unraw": "^3.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-core": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.0.tgz",
+            "integrity": "sha512-7TvbbC3dG3yM8cjqyrFXoTOpwgOC68+Z17Ro36drJwZ0k/c7QQc0dI/KvTSPHn9UfimEMdZ0q+yIIzqrAiEmww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "minim": "~0.23.8",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "short-unique-id": "^5.3.2",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "node_modules/@swagger-api/apidom-error": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.0.tgz",
+            "integrity": "sha512-JPt37oOrf73CAZNQBPffnLzU5iEUs8cT9pFmc9vy2gHQp+vjSKxeJ9F6zagTp8VnLPUq0gVjIvCQvcX8NPW2jA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.20.7"
+            }
+        },
+        "node_modules/@swagger-api/apidom-json-pointer": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.0.tgz",
+            "integrity": "sha512-11JWHr55FciYGTbcicNZrBsFEwNuLLZybi00YHJ3OBcuXcFJPKmKluLnVL7GhZYEqvLYOcVsCfInYW5MXoj00w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swaggerexpert/json-pointer": "^2.10.1"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-api-design-systems": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.0.tgz",
+            "integrity": "sha512-IskDsUkUtNas4guoChRKKkw0wOst64nRA24WuIjLf8ztfBdcl/oqx/cgy8pwWCUqNYvL9L3+sD5HeuokqMrySw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-arazzo-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.0.tgz",
+            "integrity": "sha512-n+aGSlLHyrpmCaBa9DBZkIqnNVzYAYSa010MvAwhlwtW3EbFYNwYWinbTwLqCd3leN6XWTvQYCvk0/k7/9Cq4A==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-asyncapi-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.0.tgz",
+            "integrity": "sha512-SHh3naFZlXFI0gG36tNYvJ/VO8aZsjnXIQAqJHfOE6rrpl5msJrdDatmNczh+57WPZxEZA+KTXWCqNKdeu3G3Q==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-asyncapi-3": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.0.tgz",
+            "integrity": "sha512-4vrgNYDj68hgmgZj1eGBaBr5xqIETWn4jAioiRHek4jV1FLvmxCs3nC2nYs8CzQqqJ1bqirdiirrUpqhaQvTEA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-json-schema-2019-09": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.0.tgz",
+            "integrity": "sha512-5avPMY1YbQmJIqXlu7rm3yftf4xhT2REBxpEgw8Nc7Zlbn4Z5iGXBsHr60982MwqeE6W8wA+HHQMKHM5siuhdQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-json-schema-2020-12": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.0.tgz",
+            "integrity": "sha512-zddyOxWKlQ9WPaZR0e8ykmy8AbGnDvqCqqy6BdYqKZ9Ts8ZK1XwOB2j9ruccZpoiy/rp2tow+CUf3XE5rricmQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-json-schema-draft-4": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.0.tgz",
+            "integrity": "sha512-upc0xKb3nxsYPECRDf5UygnZHTSj78xHj5+SBIHNDXoaGDhvMCtWoDVGAKFtZ+jZlIkyJt7cGAeOX0w9IV3XkA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-json-schema-draft-6": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.0.tgz",
+            "integrity": "sha512-sd/U6Y34uRqdgd3Phz1oEhO7UBCn60+OfIasFFpHZcKe7O0jTmayiaJqbpwirhwt7Fv5Ev5m58+y1nVomLnhQw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-json-schema-draft-7": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.0.tgz",
+            "integrity": "sha512-7ptuxmuh2vN1hDr3cLkYm2rl+ak2J1byoGxswucKfSb+7IaFoA36/t7kcOsE/hIO4yI7T3ZPOuNSpeg1NBVjEw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-openapi-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.0.tgz",
+            "integrity": "sha512-cAIPJhLxm/nj1kzneNySeaTahY+hH5gkGNsgbmifGnLPsC5YOOfEVMKLj18IREdXqdnxJgRbsI9Azl4g09TPkg==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-openapi-3-0": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.0.tgz",
+            "integrity": "sha512-IUEWVSuETE5DdgTJhIt6oZyRTYUV892/I9UdyTResR0Bypc7gy3YXwlzMlUZx73S2klaiFo1dL4iu/fqzA2fEg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-openapi-3-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.0.tgz",
+            "integrity": "sha512-WpUvFgOs4YMUmyeJRQEADps+U5o71YTtzKMPNr1cF1ZHKKkcRMUJL9QlJ4Y9cxAdjo6oXzXZa5922XOpwMYhxA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "node_modules/@swagger-api/apidom-ns-openapi-3-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.0.tgz",
+            "integrity": "sha512-mUErHIq8rHVoOrkHnRj3mhoNYVIl8th474/m0+E8OB2wBAe0KgiczaJX9KkBQoAo5XIxoRfmI5T3bp+fRabwCA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.0.tgz",
+            "integrity": "sha512-0OdwcnV/QF+Vs3Vj0dTmlRHEp9WQg9aBvWWl8Fq25OviyDhGGRpqgkEAOjtVYCH3XyZ1Xz+jhIDOdd5pxBajsA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.0.tgz",
+            "integrity": "sha512-K714DT6nFW+ZM9LTo+c120zkUjsEcIFO2DU+0cnzReRyenb1x6RZe+uOqTt7iWohnnWp2FV/j0exd/mCsxW65Q==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-arazzo-json-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.0.tgz",
+            "integrity": "sha512-z9K6XEr3AafV2EA+1pfW+8VoMCCSSpm2IU7oUTjSnhxRb5t/DZR4Qg8FEK8tRKdS2BO2kFFLb2xikrY3Qx8B+g==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.0.tgz",
+            "integrity": "sha512-HPb7Wzr+cj0IJkRRlqsK1tNCQXivuGRP4iB2yek16sQZXo2eqSUZ3j3Lz/WwWgnN/FWGAODm4bj9+EhGQ11TnA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.0.tgz",
+            "integrity": "sha512-sQenLXZRmTDQehe3JCSQpz6jpE3DhMQ0aoe2gpNqo23Gt/4oeW6nAP2h49q9Ne+CHPp0ApFUUyIXF7UTmbUWqA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.0.tgz",
+            "integrity": "sha512-aGnG3AYp4Qsimn1FOP0B9leYCJAQVockzHqyJj30xiNAXquBMXr6lq3L2/AEsmpDGv/x/++YJ4p2ggSxy12QNw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.0.tgz",
+            "integrity": "sha512-iIRlB8B46UPiu0EkKhq1TvwloBgObASJ5ROx8rhT5+Pj+BBegE+KIY02EUKwcz5FgXJrH3XcltLiI7ZA68347Q==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.0.tgz",
+            "integrity": "sha512-BF2ZyQYMUNrjP1nMneX6ZD2IWBLycWpxg3yllXDCJtfdQT/IMzldIPKCNI9qoBE57lM6j2hpy+Jd86QJk20t2w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-json": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.0.tgz",
+            "integrity": "sha512-DObW0LxYwif0erzGoXiEAZ6ecc/18LIEKxjEAc5Bw2M5I0C/iGW4y/UxAywihGvhMEo1gOvdO6w9Jh6UnuPVmA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "tree-sitter": "=0.21.1",
+                "tree-sitter-json": "=0.24.8",
+                "web-tree-sitter": "=0.24.5"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.0.tgz",
+            "integrity": "sha512-dREUHAEHVry9aSGjqDpYF9Wzm1lgUkV6EgoYDflyQ9HxgCwhucDPFmUgI7UaR0G6bplnJumMcZXh1I1TGn1v7Q==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.0.tgz",
+            "integrity": "sha512-U/NZpvuj9IpUS48zF2tYbgW2AtTw6Yi6kXNiHUtgUEomxYdb6XQeKLDGvgeWjgAgfUROohakcH+wx713VCGxfQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.0.tgz",
+            "integrity": "sha512-fYarNeaz39oKZ6VwqwON+IeJszidZGPvUYDfggLaar81NGimrz07y1U+DhAf96IX3qgUa2J6Fu3Bv1r57hs6Ng==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.0.tgz",
+            "integrity": "sha512-jtMoAH3R73bQUc4D2cJTUUvO4iJz9CV1W4+zoU/gT2l6h8Ji5EhZH0/VyynUk4J6mW/GdwxUN/q5z2P/DtSmfA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.0.tgz",
+            "integrity": "sha512-e8L4kHahgkOIzCCSGs5jTahXLInERNr37teSLS4SuqYgSVWr9AVXuNvpHNYGeMECD8briGIGfAAtnZChCGYrEA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.0.tgz",
+            "integrity": "sha512-s+AXnNzLeAk28jUAeXwTSR1AlX+TXIAt2GfFgWUAV+SFw2OhRpoKYLzItN3n2UsHselqHvfyUL9xNCJBZleQtQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.0.tgz",
+            "integrity": "sha512-xyUyehHhB+BSOAT7mYGqmcEozuLKxmx1Hug97O9SVgNU8QTClc95+VWrAHhJbn8juPR6y2vSwm/wrQDwb4yq7w==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.0.tgz",
+            "integrity": "sha512-u7Y98zdjEs+0Upa8TdxOsb7z8hYJmLz9lVleRiB7rqysVga6oSDI5NAFdLVqMB6uAUuFi/tyiuiFT4Qosfd6Vw==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.0.tgz",
+            "integrity": "sha512-FZK9KfwiTnNc+imxg7Wu2ktKhXCYPeFQZ1uZJzJL/hk1n+zyPfRY/4Aue4HzDcG8+wbItd3dRjKClFanVZAXoA==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "tree-sitter": "=0.22.4",
+                "web-tree-sitter": "=0.24.5"
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/@tree-sitter-grammars/tree-sitter-yaml": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz",
+            "integrity": "sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-addon-api": "^8.3.1",
+                "node-gyp-build": "^4.8.4"
+            },
+            "peerDependencies": {
+                "tree-sitter": "^0.22.4"
+            },
+            "peerDependenciesMeta": {
+                "tree-sitter": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
+            "version": "0.22.4",
+            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+            "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-addon-api": "^8.3.0",
+                "node-gyp-build": "^4.8.4"
+            }
+        },
+        "node_modules/@swagger-api/apidom-reference": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.0.tgz",
+            "integrity": "sha512-ftqegYrxxl9UwQFbdVOtXIqNolVd25M5u53X8fP96Wx6lEVr5Ed7B6+dzch8ttCUmKeoLIeagvt76b6BoYtnLw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "axios": "^1.15.0",
+                "minimatch": "^10.2.1",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            },
+            "optionalDependencies": {
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0"
+            }
+        },
+        "node_modules/@swagger-api/apidom-reference/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@swagger-api/apidom-reference/node_modules/brace-expansion": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@swagger-api/apidom-reference/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@swaggerexpert/cookie": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@swaggerexpert/cookie/-/cookie-2.0.2.tgz",
+            "integrity": "sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "apg-lite": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
+        "node_modules/@swaggerexpert/json-pointer": {
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-2.10.2.tgz",
+            "integrity": "sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "apg-lite": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
         },
         "node_modules/@trivago/prettier-plugin-sort-imports": {
             "version": "6.0.2",
@@ -2311,6 +3027,15 @@
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true
         },
+        "node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
         "node_modules/@types/is-deflate": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@types/is-deflate/-/is-deflate-1.0.0.tgz",
@@ -2353,11 +3078,26 @@
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
             "license": "MIT"
         },
+        "node_modules/@types/prismjs": {
+            "version": "1.26.6",
+            "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+            "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+            "license": "MIT"
+        },
+        "node_modules/@types/ramda": {
+            "version": "0.30.2",
+            "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
+            "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
+            "license": "MIT",
+            "dependencies": {
+                "types-ramda": "^0.30.1"
+            }
+        },
         "node_modules/@types/react": {
             "version": "19.2.14",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -2378,6 +3118,35 @@
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
             "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/swagger-ui-react": {
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@types/swagger-ui-react/-/swagger-ui-react-5.18.0.tgz",
+            "integrity": "sha512-c2M9adVG7t28t1pq19K9Jt20VLQf0P/fwJwnfcmsVVsdkwCWhRmbKDu+tIs0/NGwJ/7GY8lBx+iKZxuDI5gDbw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/react": "*"
+            }
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "license": "MIT"
+        },
+        "node_modules/@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2865,6 +3634,12 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/apg-lite": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.5.tgz",
+            "integrity": "sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/are-docs-informative": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
@@ -2874,6 +3649,12 @@
                 "node": ">=14"
             }
         },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "license": "Python-2.0"
+        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2882,6 +3663,47 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "license": "MIT"
+        },
+        "node_modules/autolinker": {
+            "version": "3.16.2",
+            "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
+            "integrity": "sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/axios": {
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
             }
         },
         "node_modules/babel-plugin-macros": {
@@ -2906,6 +3728,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/blake3-wasm": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -2920,6 +3762,77 @@
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/callsites": {
@@ -2941,11 +3854,47 @@
                 "node": ">=18"
             }
         },
+        "node_modules/character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-entities-legacy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-reference-invalid": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/cjs-module-lexer": {
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
             "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/classnames": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+            "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
             "license": "MIT"
         },
         "node_modules/cli-cursor": {
@@ -2988,6 +3937,28 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "license": "MIT",
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/comma-separated-tokens": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+            "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/commander": {
             "version": "14.0.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -3025,6 +3996,26 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/copy-to-clipboard": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+            "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+            "license": "MIT",
+            "dependencies": {
+                "toggle-selection": "^1.0.6"
+            }
+        },
+        "node_modules/core-js-pure": {
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+            "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
             }
         },
         "node_modules/cosmiconfig": {
@@ -3066,6 +4057,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "license": "MIT"
+        },
         "node_modules/csstype": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3088,11 +4085,68 @@
                 }
             }
         },
+        "node_modules/decode-named-character-reference": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+            "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+            "license": "MIT",
+            "dependencies": {
+                "character-entities": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
+        },
+        "node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4.0"
+            }
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
@@ -3101,6 +4155,38 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+            "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
+        },
+        "node_modules/drange": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+            "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/emoji-regex": {
@@ -3141,6 +4227,15 @@
                 "url": "https://github.com/sponsors/antfu"
             }
         },
+        "node_modules/es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/es-errors": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -3156,6 +4251,33 @@
             "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/esbuild": {
             "version": "0.27.3",
@@ -3513,6 +4635,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fast-json-patch": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+            "license": "MIT"
+        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3525,6 +4653,19 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
+        },
+        "node_modules/fault": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+            "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+            "license": "MIT",
+            "dependencies": {
+                "format": "^0.2.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/fdir": {
             "version": "6.5.0",
@@ -3599,6 +4740,65 @@
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true
         },
+        "node_modules/follow-redirects": {
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "license": "MIT",
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/format": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+            "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3636,6 +4836,94 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "license": "MIT",
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/hasown": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -3647,6 +4935,51 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/hast-util-parse-selector": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hastscript": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/highlightjs-vue": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+            "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+            "license": "CC0-1.0"
         },
         "node_modules/hono": {
             "version": "4.12.15",
@@ -3688,6 +5021,26 @@
                 "url": "https://github.com/sponsors/typicode"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3696,6 +5049,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
+            }
+        },
+        "node_modules/immutable": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+            "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/import-fresh": {
@@ -3723,11 +5085,62 @@
                 "node": ">=0.8.19"
             }
         },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "license": "ISC"
+        },
+        "node_modules/invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "node_modules/is-alphabetical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-alphanumerical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-alphabetical": "^2.0.0",
+                "is-decimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "license": "MIT"
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
@@ -3742,6 +5155,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-decimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/is-deflate": {
@@ -3794,6 +5217,37 @@
                 "node": ">=4"
             }
         },
+        "node_modules/is-hexadecimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "license": "MIT",
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "license": "MIT"
+        },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3807,11 +5261,29 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/js-file-download": {
+            "version": "0.4.12",
+            "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
+            "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg==",
+            "license": "MIT"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "license": "MIT"
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
         },
         "node_modules/jsdoc-type-pratt-parser": {
             "version": "7.2.0",
@@ -4215,11 +5687,23 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+            "license": "MIT"
+        },
         "node_modules/lodash-es": {
             "version": "4.18.1",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
             "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "dev": true
+        },
+        "node_modules/lodash.debounce": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+            "license": "MIT"
         },
         "node_modules/log-update": {
             "version": "6.1.0",
@@ -4258,6 +5742,32 @@
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
             }
         },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
+        "node_modules/lowlight": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+            "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+            "license": "MIT",
+            "dependencies": {
+                "fault": "^1.0.0",
+                "highlight.js": "~10.7.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4266,6 +5776,36 @@
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
         "node_modules/mimic-function": {
@@ -4299,6 +5839,18 @@
             },
             "engines": {
                 "node": ">=18.0.0"
+            }
+        },
+        "node_modules/minim": {
+            "version": "0.23.8",
+            "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.8.tgz",
+            "integrity": "sha512-bjdr2xW1dBCMsMGGsUeqM4eFI60m94+szhxWys+B1ztIt6gWSfeGBdSVCIawezeHYLYn0j6zrsXdQS/JllBzww==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash": "^4.15.0"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/minimatch": {
@@ -4348,6 +5900,89 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "node_modules/neotraverse": {
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+            "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/node-abort-controller": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+            "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
+            "license": "MIT"
+        },
+        "node_modules/node-addon-api": {
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+            "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": "^18 || ^20 || >= 21"
+            }
+        },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "deprecated": "Use your platform's native DOMException instead",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
+        "node_modules/node-fetch-commonjs": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.3.2.tgz",
+            "integrity": "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A==",
+            "license": "MIT",
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
+            }
+        },
+        "node_modules/node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "node-gyp-build": "bin.js",
+                "node-gyp-build-optional": "optional.js",
+                "node-gyp-build-test": "build-test.js"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/object-deep-merge": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
@@ -4379,6 +6014,30 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/openapi-path-templating": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-2.2.1.tgz",
+            "integrity": "sha512-eN14VrDvl/YyGxxrkGOHkVkWEoPyhyeydOUrbvjoz8K5eIGgELASwN1eqFOJ2CTQMGCy2EntOK1KdtJ8ZMekcg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "apg-lite": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=12.20.0"
+            }
+        },
+        "node_modules/openapi-server-url-templating": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.3.0.tgz",
+            "integrity": "sha512-DPlCms3KKEbjVQb0spV6Awfn6UWNheuG/+folQPzh/wUaKwuqvj8zt5gagD7qoyxtE03cIiKPgLFS3Q8Bz00uQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "apg-lite": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/openapi3-ts": {
@@ -4453,6 +6112,31 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/parse-entities": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "character-entities-legacy": "^3.0.0",
+                "character-reference-invalid": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "is-alphanumerical": "^2.0.0",
+                "is-decimal": "^2.0.0",
+                "is-hexadecimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/parse-entities/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "license": "MIT"
         },
         "node_modules/parse-imports-exports": {
             "version": "0.2.4",
@@ -4551,6 +6235,15 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.5.12",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -4604,6 +6297,45 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/prismjs": {
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "license": "MIT",
+            "dependencies": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            }
+        },
+        "node_modules/property-information": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+            "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4612,6 +6344,60 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "license": "MIT"
+        },
+        "node_modules/ramda": {
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
+            "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ramda"
+            }
+        },
+        "node_modules/ramda-adjunct": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
+            "integrity": "sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.3"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ramda-adjunct"
+            },
+            "peerDependencies": {
+                "ramda": ">= 0.30.0"
+            }
+        },
+        "node_modules/randexp": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+            "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+            "license": "MIT",
+            "dependencies": {
+                "drange": "^1.0.2",
+                "ret": "^0.2.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
             }
         },
         "node_modules/react": {
@@ -4634,6 +6420,155 @@
             "peerDependencies": {
                 "react": "^19.2.5"
             }
+        },
+        "node_modules/react-immutable-proptypes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.2.0.tgz",
+            "integrity": "sha512-Vf4gBsePlwdGvSZoLSBfd4HAP93HDauMY4fDjXhreg/vg6F3Fj/MXDNyTbltPC/xZKmZc+cjLu3598DdYK6sgQ==",
+            "license": "MIT",
+            "dependencies": {
+                "invariant": "^2.2.2"
+            },
+            "peerDependencies": {
+                "immutable": ">=3.6.2"
+            }
+        },
+        "node_modules/react-immutable-pure-component": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/react-immutable-pure-component/-/react-immutable-pure-component-2.2.2.tgz",
+            "integrity": "sha512-vkgoMJUDqHZfXXnjVlG3keCxSO/U6WeDQ5/Sl0GK2cH8TOxEzQ5jXqDXHEL/jqk6fsNxV05oH5kD7VNMUE2k+A==",
+            "license": "MIT",
+            "peerDependencies": {
+                "immutable": ">= 2 || >= 4.0.0-rc",
+                "react": ">= 16.6",
+                "react-dom": ">= 16.6"
+            }
+        },
+        "node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+            "license": "MIT"
+        },
+        "node_modules/react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            },
+            "peerDependencies": {
+                "@types/react": "^18.2.25 || ^19",
+                "react": "^18.0 || ^19",
+                "redux": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "redux": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-syntax-highlighter": {
+            "version": "16.1.1",
+            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+            "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.28.4",
+                "highlight.js": "^10.4.1",
+                "highlightjs-vue": "^1.0.0",
+                "lowlight": "^1.17.0",
+                "prismjs": "^1.30.0",
+                "refractor": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 16.20.2"
+            },
+            "peerDependencies": {
+                "react": ">= 0.14.0"
+            }
+        },
+        "node_modules/redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+            "license": "MIT"
+        },
+        "node_modules/redux-immutable": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/redux-immutable/-/redux-immutable-4.0.0.tgz",
+            "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg==",
+            "license": "BSD-3-Clause",
+            "peerDependencies": {
+                "immutable": "^3.8.1 || ^4.0.0-rc.1"
+            }
+        },
+        "node_modules/refractor": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+            "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/prismjs": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "parse-entities": "^4.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/remarkable": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
+            "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.10",
+                "autolinker": "^3.11.0"
+            },
+            "bin": {
+                "remarkable": "bin/remarkable.js"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/remarkable/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+            "license": "MIT"
+        },
+        "node_modules/reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+            "license": "MIT"
         },
         "node_modules/reserved-identifiers": {
             "version": "1.2.0",
@@ -4694,6 +6629,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/ret": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+            "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/rfdc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -4735,6 +6679,26 @@
                 "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/scheduler": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4751,6 +6715,58 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/serialize-error": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+            "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "type-fest": "^0.20.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/sha.js": {
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+            "license": "(MIT AND BSD-3-Clause)",
+            "dependencies": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
+            },
+            "bin": {
+                "sha.js": "bin.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/sharp": {
@@ -4818,6 +6834,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/short-unique-id": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.3.2.tgz",
+            "integrity": "sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg==",
+            "license": "Apache-2.0",
+            "bin": {
+                "short-unique-id": "bin/short-unique-id",
+                "suid": "bin/short-unique-id"
+            }
+        },
         "node_modules/siginfo": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -4874,6 +6900,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/space-separated-tokens": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+            "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/spdx-exceptions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
@@ -4895,6 +6931,12 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
             "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
             "dev": true
+        },
+        "node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/stackback": {
             "version": "0.0.2",
@@ -4971,6 +7013,114 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/swagger-client": {
+            "version": "3.37.3",
+            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.3.tgz",
+            "integrity": "sha512-PZv5smQPnPwfP6mnkq96fOp/RNDKBqd8vfwE4UuwA229wsesj20yd7RadXx+9uLBC3c0H6cu/H+bnbMTWG6oUQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.22.15",
+                "@scarf/scarf": "=1.4.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-reference": "^1.11.0",
+                "@swaggerexpert/cookie": "^2.0.2",
+                "deepmerge": "~4.3.0",
+                "fast-json-patch": "^3.0.0-1",
+                "js-yaml": "^4.1.0",
+                "neotraverse": "=0.6.18",
+                "node-abort-controller": "^3.1.1",
+                "node-fetch-commonjs": "^3.3.2",
+                "openapi-path-templating": "^2.2.1",
+                "openapi-server-url-templating": "^1.3.0",
+                "ramda": "^0.30.1",
+                "ramda-adjunct": "^5.1.0"
+            }
+        },
+        "node_modules/swagger-ui-react": {
+            "version": "5.32.5",
+            "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.5.tgz",
+            "integrity": "sha512-u86Qx36C5FvmJFVGMF3s62dxR3l0EfUmlylJVqCJ4vL0tvfd38kNdCQan9app6Y+C25uqVAjGLYu2w87UMD35Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime-corejs3": "^7.27.1",
+                "@scarf/scarf": "=1.4.0",
+                "base64-js": "^1.5.1",
+                "buffer": "^6.0.3",
+                "classnames": "^2.5.1",
+                "css.escape": "1.5.1",
+                "deep-extend": "0.6.0",
+                "dompurify": "^3.4.0",
+                "ieee754": "^1.2.1",
+                "immutable": "^3.x.x",
+                "js-file-download": "^0.4.12",
+                "js-yaml": "=4.1.1",
+                "lodash": "^4.18.1",
+                "prop-types": "^15.8.1",
+                "randexp": "^0.5.3",
+                "randombytes": "^2.1.0",
+                "react-copy-to-clipboard": "5.1.0",
+                "react-debounce-input": "=3.3.0",
+                "react-immutable-proptypes": "2.2.0",
+                "react-immutable-pure-component": "^2.2.0",
+                "react-inspector": "^6.0.1",
+                "react-redux": "^9.2.0",
+                "react-syntax-highlighter": "^16.0.0",
+                "redux": "^5.0.1",
+                "redux-immutable": "^4.0.0",
+                "remarkable": "^2.0.1",
+                "reselect": "^5.1.1",
+                "serialize-error": "^8.1.0",
+                "sha.js": "^2.4.12",
+                "swagger-client": "^3.37.3",
+                "url-parse": "^1.5.10",
+                "xml": "=1.0.1",
+                "xml-but-prettier": "^1.0.1",
+                "zenscroll": "^4.0.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0 <20",
+                "react-dom": ">=16.8.0 <20"
+            }
+        },
+        "node_modules/swagger-ui-react/node_modules/react-copy-to-clipboard": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
+            "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+            "license": "MIT",
+            "dependencies": {
+                "copy-to-clipboard": "^3.3.1",
+                "prop-types": "^15.8.1"
+            },
+            "peerDependencies": {
+                "react": "^15.3.0 || 16 || 17 || 18"
+            }
+        },
+        "node_modules/swagger-ui-react/node_modules/react-debounce-input": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.3.0.tgz",
+            "integrity": "sha512-VEqkvs8JvY/IIZvh71Z0TC+mdbxERvYF33RcebnodlsUZ8RSgyKe2VWaHXv4+/8aoOgXLxWrdsYs2hDhcwbUgA==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash.debounce": "^4",
+                "prop-types": "^15.8.1"
+            },
+            "peerDependencies": {
+                "react": "^15.3.0 || 16 || 17 || 18"
+            }
+        },
+        "node_modules/swagger-ui-react/node_modules/react-inspector": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.2.tgz",
+            "integrity": "sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.4 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/tinybench": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5015,6 +7165,20 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/to-buffer": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+            "license": "MIT",
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/to-valid-identifier": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
@@ -5031,6 +7195,44 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/toggle-selection": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+            "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+            "license": "MIT"
+        },
+        "node_modules/tree-sitter": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+            "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-addon-api": "^8.0.0",
+                "node-gyp-build": "^4.8.0"
+            }
+        },
+        "node_modules/tree-sitter-json": {
+            "version": "0.24.8",
+            "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",
+            "integrity": "sha512-Tc9ZZYwHyWZ3Tt1VEw7Pa2scu1YO7/d2BCBbKTx5hXwig3UfdQjsOPkPyLpDJOn/m1UBEWYAtSdGAwCSyagBqQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "node-addon-api": "^8.2.2",
+                "node-gyp-build": "^4.8.2"
+            },
+            "peerDependencies": {
+                "tree-sitter": "^0.21.1"
+            },
+            "peerDependenciesMeta": {
+                "tree-sitter": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/ts-api-utils": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -5043,13 +7245,23 @@
                 "typescript": ">=4.8.4"
             }
         },
+        "node_modules/ts-mixer": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+            "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+            "license": "MIT"
+        },
+        "node_modules/ts-toolbelt": {
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+            "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+            "license": "Apache-2.0"
+        },
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
+            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -5061,6 +7273,41 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/types-ramda": {
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
+            "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
+            "license": "MIT",
+            "dependencies": {
+                "ts-toolbelt": "^9.6.0"
             }
         },
         "node_modules/typescript": {
@@ -5125,6 +7372,12 @@
                 "pathe": "^2.0.3"
             }
         },
+        "node_modules/unraw": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+            "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg==",
+            "license": "MIT"
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5133,6 +7386,25 @@
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/url-parse": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/vite": {
@@ -5295,6 +7567,22 @@
                 }
             }
         },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/web-tree-sitter": {
+            "version": "0.24.5",
+            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.5.tgz",
+            "integrity": "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==",
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5308,6 +7596,27 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/why-is-node-running": {
@@ -5439,6 +7748,21 @@
                 }
             }
         },
+        "node_modules/xml": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+            "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+            "license": "MIT"
+        },
+        "node_modules/xml-but-prettier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml-but-prettier/-/xml-but-prettier-1.0.1.tgz",
+            "integrity": "sha512-C2CJaadHrZTqESlH03WOyw0oZTtoy2uEg6dSDF6YRg+9GnYNub53RRemLpnvtbHDFelxMx4LajiFsYeR6XJHgQ==",
+            "license": "MIT",
+            "dependencies": {
+                "repeat-string": "^1.5.2"
+            }
+        },
         "node_modules/yaml": {
             "version": "2.8.3",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -5487,6 +7811,12 @@
                 "@poppinss/exception": "^1.2.2",
                 "error-stack-parser-es": "^1.0.5"
             }
+        },
+        "node_modules/zenscroll": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/zenscroll/-/zenscroll-4.0.2.tgz",
+            "integrity": "sha512-jEA1znR7b4C/NnaycInCU6h/d15ZzCd1jmsruqOKnZP6WXQSMH3W2GL+OXbkruslU4h+Tzuos0HdswzRUk/Vgg==",
+            "license": "Unlicense"
         },
         "node_modules/zod": {
             "version": "4.3.6",
@@ -5710,6 +8040,14 @@
             "version": "7.29.2",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
             "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
+        },
+        "@babel/runtime-corejs3": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+            "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
+            "requires": {
+                "core-js-pure": "^3.48.0"
+            }
         },
         "@babel/template": {
             "version": "7.28.6",
@@ -6696,6 +9034,11 @@
             "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
             "dev": true
         },
+        "@scarf/scarf": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+            "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="
+        },
         "@sentry/cloudflare": {
             "version": "10.50.0",
             "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.50.0.tgz",
@@ -6733,6 +9076,632 @@
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true
+        },
+        "@swagger-api/apidom-ast": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ast/-/apidom-ast-1.11.0.tgz",
+            "integrity": "sha512-poLd6eNipLCFCrxjZD+E9E0Z85CLfFzueNiVcYj86rwMp2OszYsTzZS2jz82yR/usNCjXCpkQ2xEXWSmDhefPg==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "unraw": "^3.0.0"
+            }
+        },
+        "@swagger-api/apidom-core": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-core/-/apidom-core-1.11.0.tgz",
+            "integrity": "sha512-7TvbbC3dG3yM8cjqyrFXoTOpwgOC68+Z17Ro36drJwZ0k/c7QQc0dI/KvTSPHn9UfimEMdZ0q+yIIzqrAiEmww==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "minim": "~0.23.8",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "short-unique-id": "^5.3.2",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-error": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-error/-/apidom-error-1.11.0.tgz",
+            "integrity": "sha512-JPt37oOrf73CAZNQBPffnLzU5iEUs8cT9pFmc9vy2gHQp+vjSKxeJ9F6zagTp8VnLPUq0gVjIvCQvcX8NPW2jA==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.20.7"
+            }
+        },
+        "@swagger-api/apidom-json-pointer": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-json-pointer/-/apidom-json-pointer-1.11.0.tgz",
+            "integrity": "sha512-11JWHr55FciYGTbcicNZrBsFEwNuLLZybi00YHJ3OBcuXcFJPKmKluLnVL7GhZYEqvLYOcVsCfInYW5MXoj00w==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swaggerexpert/json-pointer": "^2.10.1"
+            }
+        },
+        "@swagger-api/apidom-ns-api-design-systems": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-api-design-systems/-/apidom-ns-api-design-systems-1.11.0.tgz",
+            "integrity": "sha512-IskDsUkUtNas4guoChRKKkw0wOst64nRA24WuIjLf8ztfBdcl/oqx/cgy8pwWCUqNYvL9L3+sD5HeuokqMrySw==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-ns-arazzo-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-arazzo-1/-/apidom-ns-arazzo-1-1.11.0.tgz",
+            "integrity": "sha512-n+aGSlLHyrpmCaBa9DBZkIqnNVzYAYSa010MvAwhlwtW3EbFYNwYWinbTwLqCd3leN6XWTvQYCvk0/k7/9Cq4A==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-ns-asyncapi-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-2/-/apidom-ns-asyncapi-2-1.11.0.tgz",
+            "integrity": "sha512-SHh3naFZlXFI0gG36tNYvJ/VO8aZsjnXIQAqJHfOE6rrpl5msJrdDatmNczh+57WPZxEZA+KTXWCqNKdeu3G3Q==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-ns-asyncapi-3": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-asyncapi-3/-/apidom-ns-asyncapi-3-1.11.0.tgz",
+            "integrity": "sha512-4vrgNYDj68hgmgZj1eGBaBr5xqIETWn4jAioiRHek4jV1FLvmxCs3nC2nYs8CzQqqJ1bqirdiirrUpqhaQvTEA==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-ns-json-schema-2019-09": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2019-09/-/apidom-ns-json-schema-2019-09-1.11.0.tgz",
+            "integrity": "sha512-5avPMY1YbQmJIqXlu7rm3yftf4xhT2REBxpEgw8Nc7Zlbn4Z5iGXBsHr60982MwqeE6W8wA+HHQMKHM5siuhdQ==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-7": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "@swagger-api/apidom-ns-json-schema-2020-12": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-2020-12/-/apidom-ns-json-schema-2020-12-1.11.0.tgz",
+            "integrity": "sha512-zddyOxWKlQ9WPaZR0e8ykmy8AbGnDvqCqqy6BdYqKZ9Ts8ZK1XwOB2j9ruccZpoiy/rp2tow+CUf3XE5rricmQ==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-2019-09": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "@swagger-api/apidom-ns-json-schema-draft-4": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-4/-/apidom-ns-json-schema-draft-4-1.11.0.tgz",
+            "integrity": "sha512-upc0xKb3nxsYPECRDf5UygnZHTSj78xHj5+SBIHNDXoaGDhvMCtWoDVGAKFtZ+jZlIkyJt7cGAeOX0w9IV3XkA==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "@swagger-api/apidom-ns-json-schema-draft-6": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-6/-/apidom-ns-json-schema-draft-6-1.11.0.tgz",
+            "integrity": "sha512-sd/U6Y34uRqdgd3Phz1oEhO7UBCn60+OfIasFFpHZcKe7O0jTmayiaJqbpwirhwt7Fv5Ev5m58+y1nVomLnhQw==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "@swagger-api/apidom-ns-json-schema-draft-7": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-json-schema-draft-7/-/apidom-ns-json-schema-draft-7-1.11.0.tgz",
+            "integrity": "sha512-7ptuxmuh2vN1hDr3cLkYm2rl+ak2J1byoGxswucKfSb+7IaFoA36/t7kcOsE/hIO4yI7T3ZPOuNSpeg1NBVjEw==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-6": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.4"
+            }
+        },
+        "@swagger-api/apidom-ns-openapi-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-2/-/apidom-ns-openapi-2-1.11.0.tgz",
+            "integrity": "sha512-cAIPJhLxm/nj1kzneNySeaTahY+hH5gkGNsgbmifGnLPsC5YOOfEVMKLj18IREdXqdnxJgRbsI9Azl4g09TPkg==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-ns-openapi-3-0": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-0/-/apidom-ns-openapi-3-0-1.11.0.tgz",
+            "integrity": "sha512-IUEWVSuETE5DdgTJhIt6oZyRTYUV892/I9UdyTResR0Bypc7gy3YXwlzMlUZx73S2klaiFo1dL4iu/fqzA2fEg==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-draft-4": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-ns-openapi-3-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-1/-/apidom-ns-openapi-3-1-1.11.0.tgz",
+            "integrity": "sha512-WpUvFgOs4YMUmyeJRQEADps+U5o71YTtzKMPNr1cF1ZHKKkcRMUJL9QlJ4Y9cxAdjo6oXzXZa5922XOpwMYhxA==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-ns-openapi-3-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-ns-openapi-3-2/-/apidom-ns-openapi-3-2-1.11.0.tgz",
+            "integrity": "sha512-mUErHIq8rHVoOrkHnRj3mhoNYVIl8th474/m0+E8OB2wBAe0KgiczaJX9KkBQoAo5XIxoRfmI5T3bp+fRabwCA==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-json-schema-2020-12": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "ts-mixer": "^6.0.3"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-api-design-systems-json": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-json/-/apidom-parser-adapter-api-design-systems-json-1.11.0.tgz",
+            "integrity": "sha512-0OdwcnV/QF+Vs3Vj0dTmlRHEp9WQg9aBvWWl8Fq25OviyDhGGRpqgkEAOjtVYCH3XyZ1Xz+jhIDOdd5pxBajsA==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-api-design-systems-yaml/-/apidom-parser-adapter-api-design-systems-yaml-1.11.0.tgz",
+            "integrity": "sha512-K714DT6nFW+ZM9LTo+c120zkUjsEcIFO2DU+0cnzReRyenb1x6RZe+uOqTt7iWohnnWp2FV/j0exd/mCsxW65Q==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-api-design-systems": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-arazzo-json-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-json-1/-/apidom-parser-adapter-arazzo-json-1-1.11.0.tgz",
+            "integrity": "sha512-z9K6XEr3AafV2EA+1pfW+8VoMCCSSpm2IU7oUTjSnhxRb5t/DZR4Qg8FEK8tRKdS2BO2kFFLb2xikrY3Qx8B+g==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-arazzo-yaml-1/-/apidom-parser-adapter-arazzo-yaml-1-1.11.0.tgz",
+            "integrity": "sha512-HPb7Wzr+cj0IJkRRlqsK1tNCQXivuGRP4iB2yek16sQZXo2eqSUZ3j3Lz/WwWgnN/FWGAODm4bj9+EhGQ11TnA==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-2/-/apidom-parser-adapter-asyncapi-json-2-1.11.0.tgz",
+            "integrity": "sha512-sQenLXZRmTDQehe3JCSQpz6jpE3DhMQ0aoe2gpNqo23Gt/4oeW6nAP2h49q9Ne+CHPp0ApFUUyIXF7UTmbUWqA==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-asyncapi-json-3": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-json-3/-/apidom-parser-adapter-asyncapi-json-3-1.11.0.tgz",
+            "integrity": "sha512-aGnG3AYp4Qsimn1FOP0B9leYCJAQVockzHqyJj30xiNAXquBMXr6lq3L2/AEsmpDGv/x/++YJ4p2ggSxy12QNw==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-2/-/apidom-parser-adapter-asyncapi-yaml-2-1.11.0.tgz",
+            "integrity": "sha512-iIRlB8B46UPiu0EkKhq1TvwloBgObASJ5ROx8rhT5+Pj+BBegE+KIY02EUKwcz5FgXJrH3XcltLiI7ZA68347Q==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-asyncapi-yaml-3/-/apidom-parser-adapter-asyncapi-yaml-3-1.11.0.tgz",
+            "integrity": "sha512-BF2ZyQYMUNrjP1nMneX6ZD2IWBLycWpxg3yllXDCJtfdQT/IMzldIPKCNI9qoBE57lM6j2hpy+Jd86QJk20t2w==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-3": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-json": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-json/-/apidom-parser-adapter-json-1.11.0.tgz",
+            "integrity": "sha512-DObW0LxYwif0erzGoXiEAZ6ecc/18LIEKxjEAc5Bw2M5I0C/iGW4y/UxAywihGvhMEo1gOvdO6w9Jh6UnuPVmA==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "tree-sitter": "=0.21.1",
+                "tree-sitter-json": "=0.24.8",
+                "web-tree-sitter": "=0.24.5"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-json-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-2/-/apidom-parser-adapter-openapi-json-2-1.11.0.tgz",
+            "integrity": "sha512-dREUHAEHVry9aSGjqDpYF9Wzm1lgUkV6EgoYDflyQ9HxgCwhucDPFmUgI7UaR0G6bplnJumMcZXh1I1TGn1v7Q==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-0": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-0/-/apidom-parser-adapter-openapi-json-3-0-1.11.0.tgz",
+            "integrity": "sha512-U/NZpvuj9IpUS48zF2tYbgW2AtTw6Yi6kXNiHUtgUEomxYdb6XQeKLDGvgeWjgAgfUROohakcH+wx713VCGxfQ==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-1/-/apidom-parser-adapter-openapi-json-3-1-1.11.0.tgz",
+            "integrity": "sha512-fYarNeaz39oKZ6VwqwON+IeJszidZGPvUYDfggLaar81NGimrz07y1U+DhAf96IX3qgUa2J6Fu3Bv1r57hs6Ng==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-json-3-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-json-3-2/-/apidom-parser-adapter-openapi-json-3-2-1.11.0.tgz",
+            "integrity": "sha512-jtMoAH3R73bQUc4D2cJTUUvO4iJz9CV1W4+zoU/gT2l6h8Ji5EhZH0/VyynUk4J6mW/GdwxUN/q5z2P/DtSmfA==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-2/-/apidom-parser-adapter-openapi-yaml-2-1.11.0.tgz",
+            "integrity": "sha512-e8L4kHahgkOIzCCSGs5jTahXLInERNr37teSLS4SuqYgSVWr9AVXuNvpHNYGeMECD8briGIGfAAtnZChCGYrEA==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-0/-/apidom-parser-adapter-openapi-yaml-3-0-1.11.0.tgz",
+            "integrity": "sha512-s+AXnNzLeAk28jUAeXwTSR1AlX+TXIAt2GfFgWUAV+SFw2OhRpoKYLzItN3n2UsHselqHvfyUL9xNCJBZleQtQ==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-1/-/apidom-parser-adapter-openapi-yaml-3-1-1.11.0.tgz",
+            "integrity": "sha512-xyUyehHhB+BSOAT7mYGqmcEozuLKxmx1Hug97O9SVgNU8QTClc95+VWrAHhJbn8juPR6y2vSwm/wrQDwb4yq7w==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-openapi-yaml-3-2/-/apidom-parser-adapter-openapi-yaml-3-2-1.11.0.tgz",
+            "integrity": "sha512-u7Y98zdjEs+0Upa8TdxOsb7z8hYJmLz9lVleRiB7rqysVga6oSDI5NAFdLVqMB6uAUuFi/tyiuiFT4Qosfd6Vw==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            }
+        },
+        "@swagger-api/apidom-parser-adapter-yaml-1-2": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-parser-adapter-yaml-1-2/-/apidom-parser-adapter-yaml-1-2-1.11.0.tgz",
+            "integrity": "sha512-FZK9KfwiTnNc+imxg7Wu2ktKhXCYPeFQZ1uZJzJL/hk1n+zyPfRY/4Aue4HzDcG8+wbItd3dRjKClFanVZAXoA==",
+            "optional": true,
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-ast": "^1.11.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@tree-sitter-grammars/tree-sitter-yaml": "=0.7.1",
+                "@types/ramda": "~0.30.0",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0",
+                "tree-sitter": "=0.22.4",
+                "web-tree-sitter": "=0.24.5"
+            },
+            "dependencies": {
+                "@tree-sitter-grammars/tree-sitter-yaml": {
+                    "version": "0.7.1",
+                    "resolved": "https://registry.npmjs.org/@tree-sitter-grammars/tree-sitter-yaml/-/tree-sitter-yaml-0.7.1.tgz",
+                    "integrity": "sha512-AynBwkIoQCTgjDR33bDUp9Mqq+YTco0is3n5hRApMqG9of/6A4eQsfC1/uSEeHSUyMQSYawcAWamsexnVpIP4Q==",
+                    "optional": true,
+                    "requires": {
+                        "node-addon-api": "^8.3.1",
+                        "node-gyp-build": "^4.8.4"
+                    }
+                },
+                "tree-sitter": {
+                    "version": "0.22.4",
+                    "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
+                    "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
+                    "optional": true,
+                    "requires": {
+                        "node-addon-api": "^8.3.0",
+                        "node-gyp-build": "^4.8.4"
+                    }
+                }
+            }
+        },
+        "@swagger-api/apidom-reference": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.0.tgz",
+            "integrity": "sha512-ftqegYrxxl9UwQFbdVOtXIqNolVd25M5u53X8fP96Wx6lEVr5Ed7B6+dzch8ttCUmKeoLIeagvt76b6BoYtnLw==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.26.10",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-arazzo-1": "^1.11.0",
+                "@swagger-api/apidom-ns-asyncapi-2": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-2": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-0": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-json": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-api-design-systems-yaml": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-arazzo-json-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-arazzo-yaml-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-asyncapi-json-3": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-asyncapi-yaml-3": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-json": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-json-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-0": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-json-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-0": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-1": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-openapi-yaml-3-2": "^1.11.0",
+                "@swagger-api/apidom-parser-adapter-yaml-1-2": "^1.11.0",
+                "@types/ramda": "~0.30.0",
+                "axios": "^1.15.0",
+                "minimatch": "^10.2.1",
+                "ramda": "~0.30.0",
+                "ramda-adjunct": "^5.0.0"
+            },
+            "dependencies": {
+                "balanced-match": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+                    "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
+                },
+                "brace-expansion": {
+                    "version": "5.0.5",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+                    "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+                    "requires": {
+                        "balanced-match": "^4.0.2"
+                    }
+                },
+                "minimatch": {
+                    "version": "10.2.5",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+                    "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+                    "requires": {
+                        "brace-expansion": "^5.0.5"
+                    }
+                }
+            }
+        },
+        "@swaggerexpert/cookie": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@swaggerexpert/cookie/-/cookie-2.0.2.tgz",
+            "integrity": "sha512-DPI8YJ0Vznk4CT+ekn3rcFNq1uQwvUHZhH6WvTSPD0YKBIlMS9ur2RYKghXuxxOiqOam/i4lHJH4xTIiTgs3Mg==",
+            "requires": {
+                "apg-lite": "^1.0.3"
+            }
+        },
+        "@swaggerexpert/json-pointer": {
+            "version": "2.10.2",
+            "resolved": "https://registry.npmjs.org/@swaggerexpert/json-pointer/-/json-pointer-2.10.2.tgz",
+            "integrity": "sha512-qMx1nOrzoB+PF+pzb26Q4Tc2sOlrx9Ba2UBNX9hB31Omrq+QoZ2Gly0KLrQWw4Of1AQ4J9lnD+XOdwOdcdXqqw==",
+            "requires": {
+                "apg-lite": "^1.0.4"
+            }
         },
         "@trivago/prettier-plugin-sort-imports": {
             "version": "6.0.2",
@@ -6788,6 +9757,14 @@
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true
         },
+        "@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "requires": {
+                "@types/unist": "*"
+            }
+        },
         "@types/is-deflate": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@types/is-deflate/-/is-deflate-1.0.0.tgz",
@@ -6826,11 +9803,24 @@
             "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
             "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
         },
+        "@types/prismjs": {
+            "version": "1.26.6",
+            "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+            "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw=="
+        },
+        "@types/ramda": {
+            "version": "0.30.2",
+            "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.30.2.tgz",
+            "integrity": "sha512-PyzHvjCalm2BRYjAU6nIB3TprYwMNOUY/7P/N8bSzp9W/yM2YrtGtAnnVtaCNSeOZ8DzKyFDvaqQs7LnWwwmBA==",
+            "requires": {
+                "types-ramda": "^0.30.1"
+            }
+        },
         "@types/react": {
             "version": "19.2.14",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "csstype": "^3.2.2"
             }
@@ -6847,6 +9837,31 @@
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
             "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "dev": true
+        },
+        "@types/swagger-ui-react": {
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/@types/swagger-ui-react/-/swagger-ui-react-5.18.0.tgz",
+            "integrity": "sha512-c2M9adVG7t28t1pq19K9Jt20VLQf0P/fwJwnfcmsVVsdkwCWhRmbKDu+tIs0/NGwJ/7GY8lBx+iKZxuDI5gDbw==",
+            "dev": true,
+            "requires": {
+                "@types/react": "*"
+            }
+        },
+        "@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+            "optional": true
+        },
+        "@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+        },
+        "@types/use-sync-external-store": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+            "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "8.59.1",
@@ -7145,17 +10160,58 @@
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true
         },
+        "apg-lite": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/apg-lite/-/apg-lite-1.0.5.tgz",
+            "integrity": "sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw=="
+        },
         "are-docs-informative": {
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
             "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
             "dev": true
         },
+        "argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
         "assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
             "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+        },
+        "autolinker": {
+            "version": "3.16.2",
+            "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-3.16.2.tgz",
+            "integrity": "sha512-JiYl7j2Z19F9NdTmirENSUUIIL/9MytEWtmzhfmsKPCp9E+G35Y0UNCMoM9tFigxT59qSc8Ml2dlZXOCVTYwuA==",
+            "requires": {
+                "tslib": "^2.3.0"
+            }
+        },
+        "available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "requires": {
+                "possible-typed-array-names": "^1.0.0"
+            }
+        },
+        "axios": {
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+            "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+            "requires": {
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
+            }
         },
         "babel-plugin-macros": {
             "version": "3.1.0",
@@ -7173,6 +10229,11 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
         "blake3-wasm": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -7188,6 +10249,44 @@
                 "balanced-match": "^1.0.0"
             }
         },
+        "buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            }
+        },
+        "call-bind-apply-helpers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2"
+            }
+        },
+        "call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            }
+        },
         "callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -7199,11 +10298,31 @@
             "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
             "dev": true
         },
+        "character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+        },
+        "character-entities-legacy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
+        },
+        "character-reference-invalid": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
+        },
         "cjs-module-lexer": {
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
             "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
             "dev": true
+        },
+        "classnames": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+            "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
         },
         "cli-cursor": {
             "version": "5.0.0",
@@ -7230,6 +10349,19 @@
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
         },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "comma-separated-tokens": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+            "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
+        },
         "commander": {
             "version": "14.0.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -7253,6 +10385,19 @@
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
             "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
             "dev": true
+        },
+        "copy-to-clipboard": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+            "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+            "requires": {
+                "toggle-selection": "^1.0.6"
+            }
+        },
+        "core-js-pure": {
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+            "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw=="
         },
         "cosmiconfig": {
             "version": "7.1.0",
@@ -7284,6 +10429,11 @@
                 "which": "^2.0.1"
             }
         },
+        "css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="
+        },
         "csstype": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -7297,17 +10447,73 @@
                 "ms": "^2.1.3"
             }
         },
+        "decode-named-character-reference": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+            "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+            "requires": {
+                "character-entities": "^2.0.0"
+            }
+        },
+        "deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+        },
         "deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
+        "deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+        },
+        "define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "requires": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+        },
         "detect-libc": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "dev": true
+        },
+        "dompurify": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+            "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+            "requires": {
+                "@types/trusted-types": "^2.0.7"
+            }
+        },
+        "drange": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+            "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA=="
+        },
+        "dunder-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.2.0"
+            }
         },
         "emoji-regex": {
             "version": "10.6.0",
@@ -7335,6 +10541,11 @@
             "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
             "dev": true
         },
+        "es-define-property": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+        },
         "es-errors": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -7345,6 +10556,25 @@
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
             "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
             "dev": true
+        },
+        "es-object-atoms": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "requires": {
+                "es-errors": "^1.3.0"
+            }
+        },
+        "es-set-tostringtag": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "requires": {
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            }
         },
         "esbuild": {
             "version": "0.27.3",
@@ -7587,6 +10817,11 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
+        "fast-json-patch": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+            "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ=="
+        },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -7598,6 +10833,14 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
+        },
+        "fault": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+            "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+            "requires": {
+                "format": "^0.2.0"
+            }
         },
         "fdir": {
             "version": "6.5.0",
@@ -7646,6 +10889,36 @@
             "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true
         },
+        "follow-redirects": {
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="
+        },
+        "for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "requires": {
+                "is-callable": "^1.2.7"
+            }
+        },
+        "form-data": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "es-set-tostringtag": "^2.1.0",
+                "hasown": "^2.0.2",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "format": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+            "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="
+        },
         "fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -7664,6 +10937,58 @@
             "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
             "dev": true
         },
+        "get-intrinsic": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "requires": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "math-intrinsics": "^1.1.0"
+            }
+        },
+        "get-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "requires": {
+                "dunder-proto": "^1.0.1",
+                "es-object-atoms": "^1.0.0"
+            }
+        },
+        "gopd": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+        },
+        "has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "requires": {
+                "es-define-property": "^1.0.0"
+            }
+        },
+        "has-symbols": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+        },
+        "has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "requires": {
+                "has-symbols": "^1.0.3"
+            }
+        },
         "hasown": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -7671,6 +10996,36 @@
             "requires": {
                 "function-bind": "^1.1.2"
             }
+        },
+        "hast-util-parse-selector": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+            "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "requires": {
+                "@types/hast": "^3.0.0"
+            }
+        },
+        "hastscript": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+            "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "requires": {
+                "@types/hast": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-parse-selector": "^4.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0"
+            }
+        },
+        "highlight.js": {
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+            "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+        },
+        "highlightjs-vue": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+            "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA=="
         },
         "hono": {
             "version": "4.12.15",
@@ -7689,11 +11044,21 @@
             "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
             "dev": true
         },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
         "ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
             "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true
+        },
+        "immutable": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
+            "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg=="
         },
         "import-fresh": {
             "version": "3.3.1",
@@ -7710,10 +11075,42 @@
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
             "dev": true
         },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "is-alphabetical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
+        },
+        "is-alphanumerical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+            "requires": {
+                "is-alphabetical": "^2.0.0",
+                "is-decimal": "^2.0.0"
+            }
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+        },
+        "is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
         },
         "is-core-module": {
             "version": "2.16.1",
@@ -7722,6 +11119,11 @@
             "requires": {
                 "hasown": "^2.0.2"
             }
+        },
+        "is-decimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
         },
         "is-deflate": {
             "version": "1.0.0",
@@ -7757,6 +11159,24 @@
             "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-2.0.0.tgz",
             "integrity": "sha512-jtO4Njg6q58zDo/Pu4027beSZ0VdsZlt8/5Moco6yAg+DIxb5BK/xUYqYG2+MD4+piKldXJNHxRkhEYI2fvrxA=="
         },
+        "is-hexadecimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
+        },
+        "is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "requires": {
+                "which-typed-array": "^1.1.16"
+            }
+        },
+        "isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7769,10 +11189,23 @@
             "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
             "dev": true
         },
+        "js-file-download": {
+            "version": "0.4.12",
+            "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
+            "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg=="
+        },
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "js-yaml": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "requires": {
+                "argparse": "^2.0.1"
+            }
         },
         "jsdoc-type-pratt-parser": {
             "version": "7.2.0",
@@ -7972,11 +11405,21 @@
                 "p-locate": "^5.0.0"
             }
         },
+        "lodash": {
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
+        },
         "lodash-es": {
             "version": "4.18.1",
             "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
             "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
             "dev": true
+        },
+        "lodash.debounce": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
         },
         "log-update": {
             "version": "6.1.0",
@@ -8003,6 +11446,23 @@
                 }
             }
         },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "lowlight": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+            "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+            "requires": {
+                "fault": "^1.0.0",
+                "highlight.js": "~10.7.0"
+            }
+        },
         "magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8010,6 +11470,24 @@
             "dev": true,
             "requires": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "math-intrinsics": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+        },
+        "mime-db": {
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+        },
+        "mime-types": {
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "requires": {
+                "mime-db": "1.52.0"
             }
         },
         "mimic-function": {
@@ -8030,6 +11508,14 @@
                 "workerd": "1.20260424.1",
                 "ws": "8.18.0",
                 "youch": "4.1.0-beta.10"
+            }
+        },
+        "minim": {
+            "version": "0.23.8",
+            "resolved": "https://registry.npmjs.org/minim/-/minim-0.23.8.tgz",
+            "integrity": "sha512-bjdr2xW1dBCMsMGGsUeqM4eFI60m94+szhxWys+B1ztIt6gWSfeGBdSVCIawezeHYLYn0j6zrsXdQS/JllBzww==",
+            "requires": {
+                "lodash": "^4.15.0"
             }
         },
         "minimatch": {
@@ -8058,6 +11544,47 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
             "dev": true
         },
+        "neotraverse": {
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
+            "integrity": "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="
+        },
+        "node-abort-controller": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
+            "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ=="
+        },
+        "node-addon-api": {
+            "version": "8.7.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+            "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+            "optional": true
+        },
+        "node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+        },
+        "node-fetch-commonjs": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/node-fetch-commonjs/-/node-fetch-commonjs-3.3.2.tgz",
+            "integrity": "sha512-VBlAiynj3VMLrotgwOS3OyECFxas5y7ltLcK4t41lMUZeaK15Ym4QRkqN0EQKAFL42q9i21EPKjzLUPfltR72A==",
+            "requires": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            }
+        },
+        "node-gyp-build": {
+            "version": "4.8.4",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+            "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "optional": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+        },
         "object-deep-merge": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.0.tgz",
@@ -8077,6 +11604,22 @@
             "dev": true,
             "requires": {
                 "mimic-function": "^5.0.0"
+            }
+        },
+        "openapi-path-templating": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/openapi-path-templating/-/openapi-path-templating-2.2.1.tgz",
+            "integrity": "sha512-eN14VrDvl/YyGxxrkGOHkVkWEoPyhyeydOUrbvjoz8K5eIGgELASwN1eqFOJ2CTQMGCy2EntOK1KdtJ8ZMekcg==",
+            "requires": {
+                "apg-lite": "^1.0.4"
+            }
+        },
+        "openapi-server-url-templating": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/openapi-server-url-templating/-/openapi-server-url-templating-1.3.0.tgz",
+            "integrity": "sha512-DPlCms3KKEbjVQb0spV6Awfn6UWNheuG/+folQPzh/wUaKwuqvj8zt5gagD7qoyxtE03cIiKPgLFS3Q8Bz00uQ==",
+            "requires": {
+                "apg-lite": "^1.0.4"
             }
         },
         "openapi3-ts": {
@@ -8130,6 +11673,27 @@
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "requires": {
                 "callsites": "^3.0.0"
+            }
+        },
+        "parse-entities": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "character-entities-legacy": "^3.0.0",
+                "character-reference-invalid": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "is-alphanumerical": "^2.0.0",
+                "is-decimal": "^2.0.0",
+                "is-hexadecimal": "^2.0.0"
+            },
+            "dependencies": {
+                "@types/unist": {
+                    "version": "2.0.11",
+                    "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+                    "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
+                }
             }
         },
         "parse-imports-exports": {
@@ -8203,6 +11767,11 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true
         },
+        "possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
+        },
         "postcss": {
             "version": "8.5.12",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
@@ -8226,11 +11795,69 @@
             "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true
         },
+        "prismjs": {
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+            "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="
+        },
+        "prop-types": {
+            "version": "15.8.1",
+            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+            "requires": {
+                "loose-envify": "^1.4.0",
+                "object-assign": "^4.1.1",
+                "react-is": "^16.13.1"
+            }
+        },
+        "property-information": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+            "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="
+        },
+        "proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
+        },
         "punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true
+        },
+        "querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+        },
+        "ramda": {
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.30.1.tgz",
+            "integrity": "sha512-tEF5I22zJnuclswcZMc8bDIrwRHRzf+NqVEmqg50ShAZMP7MWeR/RGDthfM/p+BlqvF2fXAzpn8i+SJcYD3alw=="
+        },
+        "ramda-adjunct": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ramda-adjunct/-/ramda-adjunct-5.1.0.tgz",
+            "integrity": "sha512-8qCpl2vZBXEJyNbi4zqcgdfHtcdsWjOGbiNSEnEBrM6Y0OKOT8UxJbIVGm1TIcjaSu2MxaWcgtsNlKlCk7o7qg==",
+            "requires": {}
+        },
+        "randexp": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+            "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+            "requires": {
+                "drange": "^1.0.2",
+                "ret": "^0.2.0"
+            }
+        },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
         },
         "react": {
             "version": "19.2.5",
@@ -8244,6 +11871,103 @@
             "requires": {
                 "scheduler": "^0.27.0"
             }
+        },
+        "react-immutable-proptypes": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.2.0.tgz",
+            "integrity": "sha512-Vf4gBsePlwdGvSZoLSBfd4HAP93HDauMY4fDjXhreg/vg6F3Fj/MXDNyTbltPC/xZKmZc+cjLu3598DdYK6sgQ==",
+            "requires": {
+                "invariant": "^2.2.2"
+            }
+        },
+        "react-immutable-pure-component": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/react-immutable-pure-component/-/react-immutable-pure-component-2.2.2.tgz",
+            "integrity": "sha512-vkgoMJUDqHZfXXnjVlG3keCxSO/U6WeDQ5/Sl0GK2cH8TOxEzQ5jXqDXHEL/jqk6fsNxV05oH5kD7VNMUE2k+A==",
+            "requires": {}
+        },
+        "react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
+        "react-redux": {
+            "version": "9.2.0",
+            "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+            "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+            "requires": {
+                "@types/use-sync-external-store": "^0.0.6",
+                "use-sync-external-store": "^1.4.0"
+            }
+        },
+        "react-syntax-highlighter": {
+            "version": "16.1.1",
+            "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-16.1.1.tgz",
+            "integrity": "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA==",
+            "requires": {
+                "@babel/runtime": "^7.28.4",
+                "highlight.js": "^10.4.1",
+                "highlightjs-vue": "^1.0.0",
+                "lowlight": "^1.17.0",
+                "prismjs": "^1.30.0",
+                "refractor": "^5.0.0"
+            }
+        },
+        "redux": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+            "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+        },
+        "redux-immutable": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/redux-immutable/-/redux-immutable-4.0.0.tgz",
+            "integrity": "sha512-SchSn/DWfGb3oAejd+1hhHx01xUoxY+V7TeK0BKqpkLKiQPVFf7DYzEaKmrEVxsWxielKfSK9/Xq66YyxgR1cg==",
+            "requires": {}
+        },
+        "refractor": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/refractor/-/refractor-5.0.0.tgz",
+            "integrity": "sha512-QXOrHQF5jOpjjLfiNk5GFnWhRXvxjUVnlFxkeDmewR5sXkr3iM46Zo+CnRR8B+MDVqkULW4EcLVcRBNOPXHosw==",
+            "requires": {
+                "@types/hast": "^3.0.0",
+                "@types/prismjs": "^1.0.0",
+                "hastscript": "^9.0.0",
+                "parse-entities": "^4.0.0"
+            }
+        },
+        "remarkable": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-2.0.1.tgz",
+            "integrity": "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==",
+            "requires": {
+                "argparse": "^1.0.10",
+                "autolinker": "^3.11.0"
+            },
+            "dependencies": {
+                "argparse": {
+                    "version": "1.0.10",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+                    "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+                    "requires": {
+                        "sprintf-js": "~1.0.2"
+                    }
+                }
+            }
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+        },
+        "reselect": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+            "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
         },
         "reserved-identifiers": {
             "version": "1.2.0",
@@ -8277,6 +12001,11 @@
                 "signal-exit": "^4.1.0"
             }
         },
+        "ret": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+            "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
+        },
         "rfdc": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -8308,6 +12037,11 @@
                 "@rolldown/pluginutils": "1.0.0-rc.17"
             }
         },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
         "scheduler": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -8317,6 +12051,37 @@
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+        },
+        "serialize-error": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+            "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+            "requires": {
+                "type-fest": "^0.20.2"
+            }
+        },
+        "set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "requires": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            }
+        },
+        "sha.js": {
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+            "requires": {
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
+            }
         },
         "sharp": {
             "version": "0.34.5",
@@ -8368,6 +12133,11 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
+        "short-unique-id": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-5.3.2.tgz",
+            "integrity": "sha512-KRT/hufMSxXKEDSQujfVE0Faa/kZ51ihUcZQAcmP04t00DvPj7Ox5anHke1sJYUtzSuiT/Y5uyzg/W7bBEGhCg=="
+        },
         "siginfo": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -8401,6 +12171,11 @@
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "dev": true
         },
+        "space-separated-tokens": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+            "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+        },
         "spdx-exceptions": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
@@ -8422,6 +12197,11 @@
             "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
             "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
             "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
         },
         "stackback": {
             "version": "0.0.2",
@@ -8470,6 +12250,99 @@
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
         },
+        "swagger-client": {
+            "version": "3.37.3",
+            "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.37.3.tgz",
+            "integrity": "sha512-PZv5smQPnPwfP6mnkq96fOp/RNDKBqd8vfwE4UuwA229wsesj20yd7RadXx+9uLBC3c0H6cu/H+bnbMTWG6oUQ==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.22.15",
+                "@scarf/scarf": "=1.4.0",
+                "@swagger-api/apidom-core": "^1.11.0",
+                "@swagger-api/apidom-error": "^1.11.0",
+                "@swagger-api/apidom-json-pointer": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-1": "^1.11.0",
+                "@swagger-api/apidom-ns-openapi-3-2": "^1.11.0",
+                "@swagger-api/apidom-reference": "^1.11.0",
+                "@swaggerexpert/cookie": "^2.0.2",
+                "deepmerge": "~4.3.0",
+                "fast-json-patch": "^3.0.0-1",
+                "js-yaml": "^4.1.0",
+                "neotraverse": "=0.6.18",
+                "node-abort-controller": "^3.1.1",
+                "node-fetch-commonjs": "^3.3.2",
+                "openapi-path-templating": "^2.2.1",
+                "openapi-server-url-templating": "^1.3.0",
+                "ramda": "^0.30.1",
+                "ramda-adjunct": "^5.1.0"
+            }
+        },
+        "swagger-ui-react": {
+            "version": "5.32.5",
+            "resolved": "https://registry.npmjs.org/swagger-ui-react/-/swagger-ui-react-5.32.5.tgz",
+            "integrity": "sha512-u86Qx36C5FvmJFVGMF3s62dxR3l0EfUmlylJVqCJ4vL0tvfd38kNdCQan9app6Y+C25uqVAjGLYu2w87UMD35Q==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.27.1",
+                "@scarf/scarf": "=1.4.0",
+                "base64-js": "^1.5.1",
+                "buffer": "^6.0.3",
+                "classnames": "^2.5.1",
+                "css.escape": "1.5.1",
+                "deep-extend": "0.6.0",
+                "dompurify": "^3.4.0",
+                "ieee754": "^1.2.1",
+                "immutable": "^3.x.x",
+                "js-file-download": "^0.4.12",
+                "js-yaml": "=4.1.1",
+                "lodash": "^4.18.1",
+                "prop-types": "^15.8.1",
+                "randexp": "^0.5.3",
+                "randombytes": "^2.1.0",
+                "react-copy-to-clipboard": "5.1.0",
+                "react-debounce-input": "=3.3.0",
+                "react-immutable-proptypes": "2.2.0",
+                "react-immutable-pure-component": "^2.2.0",
+                "react-inspector": "^6.0.1",
+                "react-redux": "^9.2.0",
+                "react-syntax-highlighter": "^16.0.0",
+                "redux": "^5.0.1",
+                "redux-immutable": "^4.0.0",
+                "remarkable": "^2.0.1",
+                "reselect": "^5.1.1",
+                "serialize-error": "^8.1.0",
+                "sha.js": "^2.4.12",
+                "swagger-client": "^3.37.3",
+                "url-parse": "^1.5.10",
+                "xml": "=1.0.1",
+                "xml-but-prettier": "^1.0.1",
+                "zenscroll": "^4.0.2"
+            },
+            "dependencies": {
+                "react-copy-to-clipboard": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/react-copy-to-clipboard/-/react-copy-to-clipboard-5.1.0.tgz",
+                    "integrity": "sha512-k61RsNgAayIJNoy9yDsYzDe/yAZAzEbEgcz3DZMhF686LEyukcE1hzurxe85JandPUG+yTfGVFzuEw3xt8WP/A==",
+                    "requires": {
+                        "copy-to-clipboard": "^3.3.1",
+                        "prop-types": "^15.8.1"
+                    }
+                },
+                "react-debounce-input": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/react-debounce-input/-/react-debounce-input-3.3.0.tgz",
+                    "integrity": "sha512-VEqkvs8JvY/IIZvh71Z0TC+mdbxERvYF33RcebnodlsUZ8RSgyKe2VWaHXv4+/8aoOgXLxWrdsYs2hDhcwbUgA==",
+                    "requires": {
+                        "lodash.debounce": "^4",
+                        "prop-types": "^15.8.1"
+                    }
+                },
+                "react-inspector": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-6.0.2.tgz",
+                    "integrity": "sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==",
+                    "requires": {}
+                }
+            }
+        },
         "tinybench": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8498,6 +12371,16 @@
             "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
             "dev": true
         },
+        "to-buffer": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+            "requires": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            }
+        },
         "to-valid-identifier": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
@@ -8508,6 +12391,31 @@
                 "reserved-identifiers": "^1.0.0"
             }
         },
+        "toggle-selection": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+            "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+        },
+        "tree-sitter": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+            "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+            "optional": true,
+            "requires": {
+                "node-addon-api": "^8.0.0",
+                "node-gyp-build": "^4.8.0"
+            }
+        },
+        "tree-sitter-json": {
+            "version": "0.24.8",
+            "resolved": "https://registry.npmjs.org/tree-sitter-json/-/tree-sitter-json-0.24.8.tgz",
+            "integrity": "sha512-Tc9ZZYwHyWZ3Tt1VEw7Pa2scu1YO7/d2BCBbKTx5hXwig3UfdQjsOPkPyLpDJOn/m1UBEWYAtSdGAwCSyagBqQ==",
+            "optional": true,
+            "requires": {
+                "node-addon-api": "^8.2.2",
+                "node-gyp-build": "^4.8.2"
+            }
+        },
         "ts-api-utils": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -8515,12 +12423,20 @@
             "dev": true,
             "requires": {}
         },
+        "ts-mixer": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+            "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
+        },
+        "ts-toolbelt": {
+            "version": "9.6.0",
+            "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+            "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
+        },
         "tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "optional": true
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         },
         "type-check": {
             "version": "0.4.0",
@@ -8529,6 +12445,29 @@
             "dev": true,
             "requires": {
                 "prelude-ls": "^1.2.1"
+            }
+        },
+        "type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
+        },
+        "typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "requires": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            }
+        },
+        "types-ramda": {
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/types-ramda/-/types-ramda-0.30.1.tgz",
+            "integrity": "sha512-1HTsf5/QVRmLzcGfldPFvkVsAdi1db1BBKzi7iW3KBUlOICg/nKnFS+jGqDJS3YD8VsWbAh7JiHeBvbsw8RPxA==",
+            "requires": {
+                "ts-toolbelt": "^9.6.0"
             }
         },
         "typescript": {
@@ -8570,6 +12509,11 @@
                 "pathe": "^2.0.3"
             }
         },
+        "unraw": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+            "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
+        },
         "uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8578,6 +12522,21 @@
             "requires": {
                 "punycode": "^2.1.0"
             }
+        },
+        "url-parse": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "requires": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "requires": {}
         },
         "vite": {
             "version": "8.0.10",
@@ -8621,6 +12580,17 @@
                 "why-is-node-running": "^2.3.0"
             }
         },
+        "web-streams-polyfill": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
+        },
+        "web-tree-sitter": {
+            "version": "0.24.5",
+            "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.24.5.tgz",
+            "integrity": "sha512-+J/2VSHN8J47gQUAvF8KDadrfz6uFYVjxoxbKWDoXVsH2u7yLdarCnIURnrMA6uSRkgX3SdmqM5BOoQjPdSh5w==",
+            "optional": true
+        },
         "which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8628,6 +12598,20 @@
             "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
+            }
+        },
+        "which-typed-array": {
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "requires": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
             }
         },
         "why-is-node-running": {
@@ -8701,6 +12685,19 @@
             "dev": true,
             "requires": {}
         },
+        "xml": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+            "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="
+        },
+        "xml-but-prettier": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml-but-prettier/-/xml-but-prettier-1.0.1.tgz",
+            "integrity": "sha512-C2CJaadHrZTqESlH03WOyw0oZTtoy2uEg6dSDF6YRg+9GnYNub53RRemLpnvtbHDFelxMx4LajiFsYeR6XJHgQ==",
+            "requires": {
+                "repeat-string": "^1.5.2"
+            }
+        },
         "yaml": {
             "version": "2.8.3",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -8734,6 +12731,11 @@
                 "@poppinss/exception": "^1.2.2",
                 "error-stack-parser-es": "^1.0.5"
             }
+        },
+        "zenscroll": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/zenscroll/-/zenscroll-4.0.2.tgz",
+            "integrity": "sha512-jEA1znR7b4C/NnaycInCU6h/d15ZzCd1jmsruqOKnZP6WXQSMH3W2GL+OXbkruslU4h+Tzuos0HdswzRUk/Vgg=="
         },
         "zod": {
             "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "semver": "^7.7.4",
+        "swagger-ui-react": "^5.32.5",
         "zod": "^4.3.6"
     },
     "devDependencies": {
@@ -55,6 +56,7 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/semver": "^7.7.1",
+        "@types/swagger-ui-react": "^5.18.0",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jsdoc": "^62.9.0",

--- a/src/routes/api.page.tsx
+++ b/src/routes/api.page.tsx
@@ -1,0 +1,11 @@
+import Swagger from '../utils/jsx/islands/swagger.tsx';
+
+import type { OpenApiResponse } from './api.schema.ts';
+
+/**
+ * /api page component.
+ *
+ * @param props Page props.
+ * @param props.data OpenAPI response data.
+ */
+export default ({ data }: { data: OpenApiResponse }) => <Swagger spec={data} />;

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -109,6 +109,15 @@ const createHandleGetApi = (registry: OpenAPIRegistry) => {
             ) {
                 delete spec.components.parameters;
             }
+
+            // Sort the schemas in the components object alphabetically, for easier navigation by humans
+            if (spec.components?.schemas) {
+                spec.components.schemas = Object.fromEntries(
+                    Object.entries(spec.components.schemas).sort(([a], [b]) =>
+                        a.localeCompare(b),
+                    ),
+                );
+            }
         }
 
         return spec;

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -51,7 +51,16 @@ const createHandleGetApi = (registry: OpenAPIRegistry) => {
 
             definitions.sort((a, b) => {
                 if (a.type === 'route' && b.type === 'route') {
-                    // Sort by method first
+                    // Hoist routes with the libraries tag, as they are the core of cdnjs
+                    const aHasLibrariesTag =
+                        a.route.tags?.includes('libraries');
+                    const bHasLibrariesTag =
+                        b.route.tags?.includes('libraries');
+                    if (aHasLibrariesTag !== bHasLibrariesTag) {
+                        return aHasLibrariesTag ? -1 : 1;
+                    }
+
+                    // Otherwise, sort by method first
                     const methodOrder = [
                         'get',
                         'post',

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -7,6 +7,7 @@ import * as z from 'zod';
 
 import respond, { withCache } from '../utils/respond.ts';
 
+import ApiPage from './api.page.tsx';
 import { type OpenApiResponse, openApiResponseSchema } from './api.schema.ts';
 import { errorResponseSchema } from './errors.schema.ts';
 
@@ -113,7 +114,7 @@ const createHandleGetApi = (registry: OpenAPIRegistry) => {
         // Set a 6 hour life on this response
         withCache(ctx, 6 * 60 * 60);
 
-        return respond<OpenApiResponse>(ctx, getOrGenerateSpec());
+        return respond<OpenApiResponse>(ctx, getOrGenerateSpec(), ApiPage);
     };
 
     return handleGetApi;

--- a/src/routes/libraries.schema.ts
+++ b/src/routes/libraries.schema.ts
@@ -4,12 +4,15 @@ import { librarySchema } from '../utils/algolia.schema';
 
 export const librariesResponseSchema = z.object({
     results: z.array(
-        librarySchema.partial().and(
-            z.object({
-                name: z.string(),
-                latest: z.string().nullable(),
-            }),
-        ),
+        librarySchema
+            .partial()
+            .and(
+                z.object({
+                    name: z.string(),
+                    latest: z.string().nullable(),
+                }),
+            )
+            .openapi('LibraryResult'),
     ),
     total: z.number(),
     available: z.number(),

--- a/src/routes/library.schema.ts
+++ b/src/routes/library.schema.ts
@@ -10,7 +10,8 @@ export const libraryVersionResponseSchema = z
         rawFiles: z.array(z.string()),
         sri: z.record(z.string(), z.string()),
     })
-    .partial();
+    .partial()
+    .openapi('LibraryVersion');
 
 export type LibraryVersionResponse = z.infer<
     typeof libraryVersionResponseSchema
@@ -30,6 +31,7 @@ export const libraryResponseSchema = librarySchema
             }),
         ),
     })
-    .partial();
+    .partial()
+    .openapi('Library');
 
 export type LibraryResponse = z.infer<typeof libraryResponseSchema>;

--- a/src/utils/jsx/island.tsx
+++ b/src/utils/jsx/island.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/css';
 import { env } from 'cloudflare:workers';
 import { type ComponentType, createContext, useContext, useId } from 'react';
 import * as z from 'zod';
@@ -46,6 +47,12 @@ const serializeProps = (props: object) =>
         .replaceAll('\u2028', '\\u2028')
         .replaceAll('\u2029', '\\u2029');
 
+const styles = {
+    island: css`
+        display: contents;
+    `,
+};
+
 /**
  * Server helper for rendering an island with serialized props and entrypoint script.
  *
@@ -80,7 +87,11 @@ const Island = <T extends object>({
 
     return (
         <>
-            <div data-island={name} data-island-props={propsScriptId}>
+            <div
+                className={styles.island}
+                data-island={name}
+                data-island-props={propsScriptId}
+            >
                 <Component {...props} />
             </div>
 

--- a/src/utils/jsx/islands/swagger.tsx
+++ b/src/utils/jsx/islands/swagger.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/css';
+import { useState } from 'react';
 import SwaggerUI from 'swagger-ui-react';
 import swaggerStyles from 'swagger-ui-react/swagger-ui.css';
 
+import theme from '../../theme.ts';
 import createIsland from '../island.tsx';
 
 const styles = {
@@ -20,6 +22,21 @@ const styles = {
             }
         }
     `,
+    loader: css`
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: opacity ${theme.transition};
+        transition-delay: 0.5s;
+
+        @starting-style {
+            opacity: 0;
+        }
+    `,
 };
 
 const scopedSwaggerStyles = swaggerStyles
@@ -32,22 +49,32 @@ const scopedSwaggerStyles = swaggerStyles
  * @param props Component props.
  * @param props.spec OpenAPI specification to render.
  */
-const Swagger = ({ spec }: { spec: object }) => (
-    <>
-        <style
-            dangerouslySetInnerHTML={{
-                __html: `@layer { ${scopedSwaggerStyles} }`,
-            }}
-        />
-        <div className={styles.container}>
-            <SwaggerUI
-                spec={spec}
-                supportedSubmitMethods={['get']}
-                tryItOutEnabled
-                displayRequestDuration
+const Swagger = ({ spec }: { spec: object }) => {
+    const [loading, setLoading] = useState(true);
+
+    return (
+        <>
+            <style
+                dangerouslySetInnerHTML={{
+                    __html: `@layer { ${scopedSwaggerStyles} }`,
+                }}
             />
-        </div>
-    </>
-);
+            <div className={styles.container}>
+                <SwaggerUI
+                    spec={spec}
+                    onComplete={() => setLoading(false)}
+                    supportedSubmitMethods={['get']}
+                    tryItOutEnabled
+                    displayRequestDuration
+                />
+            </div>
+            {loading && (
+                <div className={styles.loader}>
+                    Loading OpenAPI specification...
+                </div>
+            )}
+        </>
+    );
+};
 
 export default createIsland(Swagger, 'swagger.tsx');

--- a/src/utils/jsx/islands/swagger.tsx
+++ b/src/utils/jsx/islands/swagger.tsx
@@ -1,0 +1,53 @@
+import { css } from '@emotion/css';
+import SwaggerUI from 'swagger-ui-react';
+import swaggerStyles from 'swagger-ui-react/swagger-ui.css';
+
+import createIsland from '../island.tsx';
+
+const styles = {
+    container: css`
+        .swagger-ui {
+            .scheme-container {
+                display: none;
+            }
+
+            button {
+                color: inherit;
+
+                svg {
+                    fill: currentColor;
+                }
+            }
+        }
+    `,
+};
+
+const scopedSwaggerStyles = swaggerStyles
+    .replace(/(?<=[{;]\s*)color:\s*[^;]+;/g, '')
+    .replace(/\.swagger-ui(?![\w-])/g, `.${styles.container} .swagger-ui`);
+
+/**
+ * Custom Swagger UI island component to render the OpenAPI spec for the API documentation page.
+ *
+ * @param props Component props.
+ * @param props.spec OpenAPI specification to render.
+ */
+const Swagger = ({ spec }: { spec: object }) => (
+    <>
+        <style
+            dangerouslySetInnerHTML={{
+                __html: `@layer { ${scopedSwaggerStyles} }`,
+            }}
+        />
+        <div className={styles.container}>
+            <SwaggerUI
+                spec={spec}
+                supportedSubmitMethods={['get']}
+                tryItOutEnabled
+                displayRequestDuration
+            />
+        </div>
+    </>
+);
+
+export default createIsland(Swagger, 'swagger.tsx');

--- a/src/utils/jsx/islands/swagger.tsx
+++ b/src/utils/jsx/islands/swagger.tsx
@@ -1,25 +1,217 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
+import { Iterable, List, Map } from 'immutable';
+import { type ComponentType, type ReactNode, useState } from 'react';
 import SwaggerUI from 'swagger-ui-react';
 import swaggerStyles from 'swagger-ui-react/swagger-ui.css';
 
 import theme from '../../theme.ts';
 import createIsland from '../island.tsx';
 
+const mixins = {
+    pre: css`
+        background: ${theme.background.footer} !important;
+        color: ${theme.text.primary};
+        padding: ${theme.spacing(1.5, 2)} !important;
+        border-radius: ${theme.radius};
+        font-size: ${theme.font.small.size};
+        margin: 0;
+        display: block;
+        width: 100%;
+        box-sizing: border-box;
+        max-height: ${theme.spacing(50)};
+        overflow: auto;
+    `,
+    code: css`
+        background: ${theme.background.body};
+        color: ${theme.text.primary};
+        padding: ${theme.spacing(0.25, 0.75)};
+        border-radius: ${theme.radius};
+        font-size: ${theme.font.small.size};
+    `,
+    body: css`
+        padding: ${theme.spacing(1.5, 2)};
+    `,
+};
+
 const styles = {
     container: css`
         .swagger-ui {
-            .scheme-container {
-                display: none;
+            pre {
+                ${mixins.pre};
+            }
+
+            code:not(pre code) {
+                ${mixins.code};
+            }
+
+            svg {
+                fill: currentColor;
             }
 
             button {
                 color: inherit;
+            }
 
-                svg {
-                    fill: currentColor;
+            a {
+                color: ${theme.text.brand};
+                text-decoration: none;
+
+                &:hover {
+                    text-decoration: underline;
                 }
             }
+
+            /* Remove the default styling of operation sections. */
+            .opblock {
+                margin: 0;
+                border: 0;
+                border-radius: 0;
+                background: none;
+                box-shadow: none;
+            }
+
+            /* Replace the default background of operation section headers. */
+            .opblock .opblock-section-header {
+                background: ${theme.background.footer};
+                box-shadow: none;
+                border-radius: ${theme.radius};
+            }
+
+            /* Add a consistent indicator to the "Parameters" + "Responses" tabs. */
+            .opblock .opblock-section-header .tab-item h4 span,
+            .opblock .responses-wrapper .opblock-section-header h4 {
+                position: relative;
+                display: inline-block;
+                width: fit-content;
+                flex: 0 0 auto;
+
+                &::after {
+                    content: '';
+                    display: block;
+                    position: static;
+                    transform: none;
+                    width: 100%;
+                    height: ${theme.spacing(0.5)};
+                    background: ${theme.background.brand};
+                    margin-top: ${theme.spacing(0.5)};
+                    bottom: auto;
+                    left: auto;
+                }
+            }
+
+            /* Present the "Execute" + "Clear" buttons in a single line. */
+            .opblock .execute-wrapper,
+            .opblock .btn-group {
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+                gap: ${theme.spacing(1)};
+                padding: ${theme.spacing(1.5, 2)};
+            }
+            .opblock .btn.execute {
+                flex: 1 1 auto;
+                padding: ${theme.spacing(1, 2)};
+                font-size: ${theme.font.body.size};
+                font-weight: 600;
+                background: ${theme.background.brand};
+                border-color: ${theme.background.brand};
+                color: ${theme.text.inverted};
+                box-shadow: none;
+                text-shadow: none;
+            }
+            .opblock .btn-clear {
+                flex: 0 0 auto;
+                padding: ${theme.spacing(1, 2)};
+                font-size: ${theme.font.body.size};
+                font-weight: 600;
+                color: inherit;
+            }
+
+            /* Remove the duplicate model title from standalone schemas. */
+            section.models .model-box-control:has(.model-title) {
+                display: none;
+            }
+
+            /* Replace the default SVG with +/- for the toggles in models. */
+            .model-toggle {
+                transform: none;
+                vertical-align: middle;
+                top: 0;
+
+                &::after {
+                    content: '+';
+                    background: none;
+                    width: auto;
+                    height: auto;
+                    display: inline-block;
+                    font-family: monospace;
+                    font-size: ${theme.font.small.size};
+                    font-weight: ${theme.font.small.weight};
+                    line-height: 1;
+                    vertical-align: middle;
+                    color: ${theme.text.secondary};
+                }
+            }
+            [aria-expanded='true'] > .model-toggle {
+                &::after {
+                    content: '-';
+                }
+            }
+
+            /* Make the response schema models match the example value code. */
+            .model {
+                font-size: ${theme.font.small.size};
+            }
+            .model-example .model-box {
+                ${mixins.pre};
+            }
+
+            /* Remove the default links column from the responses table. */
+            .responses-table .response-col_links {
+                display: none;
+            }
+        }
+    `,
+    wrapper: css`
+        display: block;
+        border: ${theme.spacing(0.125)} solid ${theme.background.body};
+        border-radius: ${theme.radius};
+        background: ${theme.background.navigation};
+        margin: 0 0 ${theme.spacing(1.5)};
+        overflow: hidden;
+    `,
+    summary: css`
+        ${mixins.body};
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(1.5)};
+        background: ${theme.background.footer};
+        cursor: pointer;
+
+        > span:first-child {
+            ${mixins.code};
+            font-weight: bold;
+        }
+
+        > svg:last-child {
+            margin-left: auto;
+            flex-shrink: 0;
+        }
+    `,
+    header: css`
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(1)};
+        font-size: ${theme.font.large.size};
+        font-weight: bold;
+        padding: ${theme.spacing(1.25, 2, 1.25, 1.25)};
+        margin: 0 0 ${theme.spacing(0.625)};
+        cursor: pointer;
+        color: inherit;
+
+        > svg:last-child {
+            margin-left: auto;
+            flex-shrink: 0;
         }
     `,
     loader: css`
@@ -38,6 +230,373 @@ const styles = {
         }
     `,
 };
+
+interface System {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getComponent: (name: string, container?: boolean) => ComponentType<any>;
+    getConfigs: () => Record<string, unknown>;
+    layoutSelectors: {
+        isShown: (key: readonly string[], def: boolean) => boolean;
+    };
+    layoutActions: {
+        show: (key: readonly string[], shown: boolean) => void;
+    };
+    specSelectors: {
+        isOAS3: () => boolean;
+        definitions: () => Map<string, unknown>;
+    };
+}
+
+/**
+ * Custom wrapper component for all collapsible sections of the Swagger UI.
+ *
+ * @param props Component props.
+ * @param props.children Content to display inside the wrapper.
+ */
+const Wrapper = ({ children }: { children: ReactNode }) => (
+    <div className={styles.wrapper}>{children}</div>
+);
+
+/**
+ * Custom summary component for operations and standalone schemas.
+ *
+ * @param props Component props.
+ * @param props.system Swagger UI system object passed to all components.
+ * @param props.onClick Handler to toggle the section expansion.
+ * @param props.expanded Whether the section is currently expanded.
+ * @param props.badge Text to show in the badge before the summary content.
+ * @param props.children Summary content to display.
+ */
+const Summary = ({
+    system,
+    onClick,
+    badge,
+    expanded,
+    children,
+}: {
+    system: System;
+    onClick: () => void;
+    expanded: boolean;
+    badge: ReactNode;
+    children: ReactNode;
+}) => {
+    const ArrowIcon = system.getComponent(
+        expanded ? 'ArrowUpIcon' : 'ArrowDownIcon',
+    );
+
+    return (
+        <div className={styles.summary} onClick={onClick}>
+            <span>{badge}</span>
+            {children}
+            <ArrowIcon />
+        </div>
+    );
+};
+
+/**
+ * Custom header component for collapsible sections of the Swagger UI.
+ *
+ * @param props Component props.
+ * @param props.system Swagger UI system object passed to all components.
+ * @param props.onClick Handler to toggle the section expansion.
+ * @param props.expanded Whether the section is currently expanded.
+ * @param props.children Header content to display.
+ */
+const Header = ({
+    system,
+    onClick,
+    expanded,
+    children,
+}: {
+    system: System;
+    onClick: () => void;
+    expanded: boolean;
+    children: ReactNode;
+}) => {
+    const ArrowIcon = system.getComponent(
+        expanded ? 'ArrowUpIcon' : 'ArrowDownIcon',
+    );
+
+    return (
+        <h3 className={styles.header} onClick={onClick}>
+            <span>{children}</span>
+            <ArrowIcon />
+        </h3>
+    );
+};
+
+const plugin = (system: System) => ({
+    components: {
+        /**
+         * Replace the default layout with a custom implementation that only
+         *  renders the operations and schema models, omitting other sections.
+         *
+         * @see https://github.com/swagger-api/swagger-ui/blob/v5.32.5/src/core/components/layouts/base.jsx
+         */
+        BaseLayout: () => {
+            const SvgAssets = system.getComponent('SvgAssets');
+            const Operations = system.getComponent('operations', true);
+            const Models = system.getComponent('Models', true);
+
+            return (
+                <div className="swagger-ui">
+                    <SvgAssets />
+                    <Operations />
+                    <Models />
+                </div>
+            );
+        },
+        /**
+         * Replace the default operation tag section with a custom implementation
+         *  that uses our custom `Header`.
+         *
+         * @see https://github.com/swagger-api/swagger-ui/blob/v5.32.5/src/core/components/operation-tag.jsx
+         *
+         * @param props Props passed by swagger-ui.
+         * @param props.tag Name of the tag this section represents.
+         * @param props.children Operations grouped under this tag.
+         */
+        OperationTag: ({
+            tag,
+            children,
+        }: {
+            tag: string;
+            children: ReactNode;
+        }) => {
+            const { docExpansion } = system.getConfigs();
+            const isShownKey = ['operations-tag', tag];
+            const expanded = system.layoutSelectors.isShown(
+                isShownKey,
+                docExpansion === 'full' || docExpansion === 'list',
+            );
+            const Collapse = system.getComponent('Collapse');
+            const onClick = () =>
+                system.layoutActions.show(isShownKey, !expanded);
+            const label = tag.charAt(0).toUpperCase() + tag.slice(1);
+
+            return (
+                <div
+                    className={
+                        expanded
+                            ? 'opblock-tag-section is-open'
+                            : 'opblock-tag-section'
+                    }
+                >
+                    <Header
+                        system={system}
+                        onClick={onClick}
+                        expanded={expanded}
+                    >
+                        {label}
+                    </Header>
+                    <Collapse isOpened={expanded}>{children}</Collapse>
+                </div>
+            );
+        },
+        /**
+         * Replace the default operation summary with our custom `Summary`.
+         *
+         * @see https://github.com/swagger-api/swagger-ui/blob/v5.32.5/src/core/components/operation-summary.jsx
+         *
+         * @param props Props passed by swagger-ui.
+         * @param props.isShown Whether the operation body is currently expanded.
+         * @param props.toggleShown Handler to toggle the operation body expansion.
+         * @param props.operationProps Iterable of the operation's properties.
+         */
+        OperationSummary: ({
+            isShown,
+            toggleShown,
+            operationProps,
+        }: {
+            isShown: boolean;
+            toggleShown: () => void;
+            operationProps: Iterable<string, unknown>;
+        }) => {
+            const { method, path, summary } = operationProps.toObject();
+            if (
+                typeof method !== 'string' ||
+                typeof path !== 'string' ||
+                (typeof summary !== 'undefined' && typeof summary !== 'string')
+            ) {
+                throw new Error('Invalid operationProps for OperationSummary');
+            }
+
+            return (
+                <Summary
+                    system={system}
+                    badge={method?.toUpperCase()}
+                    onClick={toggleShown}
+                    expanded={isShown}
+                >
+                    <code>
+                        {path?.split(/\//g).map((part, i) =>
+                            i === 0 ? (
+                                part
+                            ) : (
+                                <>
+                                    <wbr key={`wbr-${i}`} />/{part}
+                                </>
+                            ),
+                        )}
+                    </code>
+                    <span>{summary}</span>
+                </Summary>
+            );
+        },
+        /**
+         * Remove the default "Try it out" button as we always enable it.
+         *
+         * @see https://github.com/swagger-api/swagger-ui/blob/v5.32.5/src/core/components/try-it-out-button.jsx
+         */
+        TryItOutButton: () => null,
+        /**
+         * Replace the default models section with a custom implementation
+         *  that uses our custom `Header` + `Wrapper` + `Summary`.
+         *
+         * @see https://github.com/swagger-api/swagger-ui/blob/v5.32.5/src/core/plugins/json-schema-5/components/models.jsx
+         */
+        Models: () => {
+            const { docExpansion, defaultModelsExpandDepth = 1 } =
+                system.getConfigs();
+            const definitions = system.specSelectors.definitions();
+            if (!definitions.size || Number(defaultModelsExpandDepth) < 0)
+                return null;
+
+            const specPathBase = system.specSelectors.isOAS3()
+                ? ['components', 'schemas']
+                : ['definitions'];
+
+            const sectionExpanded = system.layoutSelectors.isShown(
+                specPathBase,
+                Number(defaultModelsExpandDepth) > 0 && docExpansion !== 'none',
+            );
+            const onSectionClick = () =>
+                system.layoutActions.show(specPathBase, !sectionExpanded);
+
+            const Collapse = system.getComponent('Collapse');
+
+            return (
+                <section
+                    className={sectionExpanded ? 'models is-open' : 'models'}
+                >
+                    <Header
+                        system={system}
+                        onClick={onSectionClick}
+                        expanded={sectionExpanded}
+                    >
+                        Schemas
+                    </Header>
+                    <Collapse isOpened={sectionExpanded}>
+                        {definitions
+                            .entrySeq()
+                            .map((entry) => {
+                                if (!entry) return null;
+
+                                const [name, schema] = entry;
+                                const fullPath = [...specPathBase, name];
+                                const expanded = system.layoutSelectors.isShown(
+                                    fullPath,
+                                    false,
+                                );
+                                const onClick = () =>
+                                    system.layoutActions.show(
+                                        fullPath,
+                                        !expanded,
+                                    );
+                                const ModelWrapper =
+                                    system.getComponent('ModelWrapper');
+
+                                return (
+                                    <Wrapper>
+                                        <Summary
+                                            system={system}
+                                            badge="SCHEMA"
+                                            onClick={onClick}
+                                            expanded={expanded}
+                                        >
+                                            <code>{name}</code>
+                                        </Summary>
+                                        {expanded && (
+                                            <div className={mixins.body}>
+                                                <ModelWrapper
+                                                    name={name}
+                                                    displayName={name}
+                                                    schema={schema}
+                                                    fullPath={fullPath}
+                                                    specPath={List(fullPath)}
+                                                    getComponent={
+                                                        system.getComponent
+                                                    }
+                                                    getConfigs={
+                                                        system.getConfigs
+                                                    }
+                                                    specSelectors={
+                                                        system.specSelectors
+                                                    }
+                                                    layoutSelectors={
+                                                        system.layoutSelectors
+                                                    }
+                                                    layoutActions={
+                                                        system.layoutActions
+                                                    }
+                                                    includeReadOnly
+                                                    includeWriteOnly
+                                                />
+                                            </div>
+                                        )}
+                                    </Wrapper>
+                                );
+                            })
+                            .toArray()}
+                    </Collapse>
+                </section>
+            );
+        },
+        /**
+         * Replace the default enum model rendering with a single line of text.
+         *
+         * @see https://github.com/swagger-api/swagger-ui/blob/v5.32.5/src/core/plugins/json-schema-5/components/enum-model.jsx
+         *
+         * @param props Props passed by swagger-ui.
+         * @param props.value Enum values to render.
+         */
+        EnumModel: ({ value }: { value: Iterable<string, unknown> }) => (
+            <span className="prop-enum">
+                Enum: [ {value.map(String).join(', ')} ]
+            </span>
+        ),
+    },
+    wrapComponents: {
+        /**
+         * Wrap model rendering to force all properties to expand by default.
+         *
+         * @see https://github.com/swagger-api/swagger-ui/blob/v5.32.5/src/core/plugins/json-schema-5/components/model.jsx
+         *
+         * @param Original Original model component to wrap.
+         */
+        Model:
+            (Original: ComponentType<Record<string, unknown>>) =>
+            (props: Record<string, unknown>) => (
+                <Original {...props} expandDepth={Infinity} />
+            ),
+        /**
+         * Wrap the entire operation with our custom `Wrapper`, matching the
+         *  wrapper we apply in `Models` for standalone schemas.
+         *
+         * @see https://github.com/swagger-api/swagger-ui/blob/v5.32.5/src/core/containers/OperationContainer.jsx
+         * @see https://github.com/swagger-api/swagger-ui/blob/v5.32.5/src/core/components/operation.jsx
+         *
+         * @param Original Original operation component to wrap.
+         */
+        operation:
+            (Original: ComponentType<Record<string, unknown>>) =>
+            (props: Record<string, unknown>) => (
+                <Wrapper>
+                    <Original {...props} />
+                </Wrapper>
+            ),
+    },
+});
 
 const scopedSwaggerStyles = swaggerStyles
     .replace(/(?<=[{;]\s*)color:\s*[^;]+;/g, '')
@@ -63,6 +622,7 @@ const Swagger = ({ spec }: { spec: object }) => {
                 <SwaggerUI
                     spec={spec}
                     onComplete={() => setLoading(false)}
+                    plugins={[plugin]}
                     supportedSubmitMethods={['get']}
                     tryItOutEnabled
                     displayRequestDuration

--- a/src/utils/jsx/json.tsx
+++ b/src/utils/jsx/json.tsx
@@ -15,9 +15,9 @@ const styles = {
  * Standard cdnjs HTML layout for pretty-printing JSON data.
  *
  * @param props Component props.
- * @param props.json Data to be pretty-printed on the page.
+ * @param props.data Data to be pretty-printed on the page.
  */
-export default ({ json }: { json: unknown }) => (
+export default ({ data }: { data: unknown }) => (
     <>
         <link
             rel="stylesheet"
@@ -29,7 +29,7 @@ export default ({ json }: { json: unknown }) => (
 
         <pre className={styles.pre}>
             <code className={cx(styles.code, 'language-json')}>
-                {JSON.stringify(json, null, 2)}
+                {JSON.stringify(data, null, 2)}
             </code>
         </pre>
 

--- a/src/utils/jsx/layout.tsx
+++ b/src/utils/jsx/layout.tsx
@@ -24,6 +24,8 @@ const styles = {
     `,
     content: css`
         flex-grow: 1;
+        isolation: isolate;
+        position: relative;
     `,
     container: css`
         margin: 0 auto;

--- a/src/utils/respond.ts
+++ b/src/utils/respond.ts
@@ -1,7 +1,7 @@
 import { cache } from '@emotion/css';
 import { env } from 'cloudflare:workers';
 import type { Context } from 'hono';
-import { createElement } from 'react';
+import { type ComponentType, createElement } from 'react';
 import { renderToString } from 'react-dom/server';
 
 import type { ErrorResponse } from '../routes/errors.schema.ts';
@@ -77,8 +77,13 @@ export const withCache = (ctx: Context, age: number, immutable = false) => {
  *
  * @param ctx Request context.
  * @param data Data to be included in the response.
+ * @param component Optional custom component to use for human-readable output (defaults to Json).
  */
-const respond = async <T = never>(ctx: Context, data: NoInfer<T>) => {
+const respond = async <T = never>(
+    ctx: Context,
+    data: NoInfer<T>,
+    component: ComponentType<{ data: NoInfer<T> }> = Json,
+) => {
     if (ctx.req.query('output') === 'human') {
         event('human-output', { ctx });
         ctx.header('X-Robots-Tag', 'noindex');
@@ -88,11 +93,7 @@ const respond = async <T = never>(ctx: Context, data: NoInfer<T>) => {
             createElement(
                 Provider,
                 null,
-                createElement(
-                    Layout,
-                    null,
-                    createElement(Json, { json: data }),
-                ),
+                createElement(Layout, null, createElement(component, { data })),
             ),
         );
         const styles = getCriticalEmotionCss(body);

--- a/src/utils/spec/request.ts
+++ b/src/utils/spec/request.ts
@@ -49,7 +49,7 @@ export const request = async (route: string, opts: RequestInit = {}) => {
                     );
             }
 
-            return Reflect.get(response, prop);
+            return Reflect.get(response, prop, response);
         },
     });
 };
@@ -63,11 +63,15 @@ export const request = async (route: string, opts: RequestInit = {}) => {
 export const beforeRequest = (route: string, opts: RequestInit = {}) => {
     let response: Response;
 
-    beforeAll(async () => {
-        response = await request(route, opts);
-    });
+    beforeAll(
+        async () => {
+            response = await request(route, opts);
+        },
+        // Allow time for the worker to compile when running against the Miniflare instance
+        externalApiUrl ? 5_000 : 30_000,
+    );
 
     return new Proxy({} as Response, {
-        get: (_, prop) => Reflect.get(response, prop),
+        get: (_, prop) => Reflect.get(response, prop, response),
     });
 };

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -20,7 +20,8 @@ export default {
         major: '#e67e22',
         critical: '#e74c3c',
     },
-    spacing: (value: number) => `${value * 8}px`,
+    spacing: (...values: number[]) =>
+        values.map((value) => `${value * 8}px`).join(' '),
     breakpoints: {
         medium: breakpoint(96),
     },

--- a/vite.client.config.ts
+++ b/vite.client.config.ts
@@ -6,6 +6,8 @@ const outputDirectory = resolve('dist-client');
 const virtualEntryPrefix = 'virtual:island-entry:';
 const hydrationRuntimePath = resolve('src/utils/island.ts');
 
+const isCssImport = (source: string) => /\.css(?:$|\?)/.test(source);
+
 const islandEntries = globSync('src/utils/jsx/islands/*.tsx')
     .filter((file) => !file.endsWith('.spec.ts'))
     .sort()
@@ -48,6 +50,22 @@ const parseCreateIslandDeclaration = (source: string) => {
 export default defineConfig({
     publicDir: false,
     plugins: [
+        {
+            name: 'raw-css-imports',
+            enforce: 'pre',
+            // Force CSS to be imported as a raw string, matching how Wrangler handles CSS imports.
+            resolveId(source, importer, options) {
+                if (!isCssImport(source)) {
+                    return null;
+                }
+
+                return this.resolve(
+                    `${source}${source.includes('?') ? '&' : '?'}raw`,
+                    importer,
+                    { ...options, skipSelf: true },
+                );
+            },
+        },
         {
             name: 'virtual-island-entries',
             resolveId(source) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,6 +9,11 @@ kv_namespaces = [ { binding = "CACHE" } ]
 command = "vite build --config vite.client.config.ts"
 watch_dir = "src"
 
+[[rules]]
+type = "Text"
+globs = [ "**/*.css" ]
+fallthrough = true
+
 [assets]
 directory = "./dist-client"
 binding = "ASSETS"


### PR DESCRIPTION
## Type of Change

- **Routes:** `/api`
- **Utilities:** `respond`

## What issue does this relate to?

cc #196 #189

### What should this PR do?

Replaces the default humam output for the `/api` route with an island component that uses the standard Swagger UI React library, with customisations applied to make it better fit the cdnjs brand.

### What are the acceptance criteria?

`/api` still returns the OpenAPI spec. `/api?output=human` now returns a Swagger UI interface. All other `/...?output=human` responses are still the pretty-printed JSON.