### PR TITLE
Disable fail-fast for scheduled test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         worker:
           - production


### PR DESCRIPTION
## Summary
- set the scheduled test matrix to `fail-fast: false`
- let production and staging scheduled test jobs both finish even if one environment fails first

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "yaml-ok"'`
- `git diff --check`
- `git diff -- .github/workflows/test.yml | gitleaks stdin --no-banner --redact --timeout 30`

I did not run `npm test` locally because this machine has Node v22.16.0 and the repo requires Node >=24.11.0 via `package.json` / `.nvmrc`. The change is limited to the GitHub Actions workflow YAML.

Fixes #215
