### PR TITLE
Silence peer dep issues for swagger-ui-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,17 @@
     "overrides": {
         "@cloudflare/vitest-pool-workers": {
             "wrangler": "$wrangler"
+        },
+        "swagger-ui-react": {
+            "react-copy-to-clipboard": {
+                "react": "$react"
+            },
+            "react-debounce-input": {
+                "react": "$react"
+            },
+            "react-inspector": {
+                "react": "$react"
+            }
         }
     }
 }


### PR DESCRIPTION
## Type of Change

- **Something else:** package.json

## What issue does this relate to?

cc #208

### What should this PR do?

The Swagger UI package includes some dependencies that state they are not compatible with React 19. We are either not using these, or they are actually compatible, so overriding the React version set for them to silence the peer dependency warnings.

### What are the acceptance criteria?

No peer dependency warnings during install.
