### PR TITLE
Add page for library version human output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
                 "react": "^19.2.6",
                 "react-dom": "^19.2.6",
                 "semver": "^7.7.4",
+                "spdx-license-ids": "^3.0.23",
                 "swagger-ui-react": "^5.32.6",
                 "zod": "^4.4.3"
             },
@@ -35,6 +36,7 @@
                 "@types/react": "^19.2.15",
                 "@types/react-dom": "^19.2.3",
                 "@types/semver": "^7.7.1",
+                "@types/spdx-license-ids": "^3.0.0",
                 "@types/swagger-ui-react": "^5.18.0",
                 "eslint": "^10.4.0",
                 "eslint-config-prettier": "^10.1.8",
@@ -3066,6 +3068,13 @@
             "version": "7.7.1",
             "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
             "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/spdx-license-ids": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+            "integrity": "sha512-x+bDiv6h46IR5lUipX/ndSWlOrwLxTFpTelLGRDcYm3vrELDaMpKFXIrIuxmpPl/I+IzMeOPBPWsribCFqmgBg==",
             "dev": true,
             "license": "MIT"
         },
@@ -6881,10 +6890,10 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.16",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-            "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
-            "dev": true
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+            "license": "CC0-1.0"
         },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
@@ -9752,6 +9761,12 @@
             "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
             "dev": true
         },
+        "@types/spdx-license-ids": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+            "integrity": "sha512-x+bDiv6h46IR5lUipX/ndSWlOrwLxTFpTelLGRDcYm3vrELDaMpKFXIrIuxmpPl/I+IzMeOPBPWsribCFqmgBg==",
+            "dev": true
+        },
         "@types/swagger-ui-react": {
             "version": "5.18.0",
             "resolved": "https://registry.npmjs.org/@types/swagger-ui-react/-/swagger-ui-react-5.18.0.tgz",
@@ -12151,10 +12166,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.16",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-            "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
-            "dev": true
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="
         },
         "sprintf-js": {
             "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@asteasolutions/zod-to-openapi": "^8.5.0",
                 "@emotion/css": "^11.13.5",
                 "@sentry/cloudflare": "^10.55.0",
+                "@tanstack/react-virtual": "^3.14.2",
                 "algoliasearch": "^5.53.0",
                 "hono": "^4.12.23",
                 "is-deflate": "^1.0.0",
@@ -2866,6 +2867,33 @@
             },
             "engines": {
                 "node": ">=12.20.0"
+            }
+        },
+        "node_modules/@tanstack/react-virtual": {
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz",
+            "integrity": "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/virtual-core": "3.17.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@tanstack/virtual-core": {
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
+            "integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
         "node_modules/@trivago/prettier-plugin-sort-imports": {
@@ -9575,6 +9603,19 @@
             "requires": {
                 "apg-lite": "^1.0.4"
             }
+        },
+        "@tanstack/react-virtual": {
+            "version": "3.14.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.2.tgz",
+            "integrity": "sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==",
+            "requires": {
+                "@tanstack/virtual-core": "3.17.0"
+            }
+        },
+        "@tanstack/virtual-core": {
+            "version": "3.17.0",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.0.tgz",
+            "integrity": "sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ=="
         },
         "@trivago/prettier-plugin-sort-imports": {
             "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "@asteasolutions/zod-to-openapi": "^8.5.0",
         "@emotion/css": "^11.13.5",
         "@sentry/cloudflare": "^10.55.0",
+        "@tanstack/react-virtual": "^3.14.2",
         "algoliasearch": "^5.53.0",
         "hono": "^4.12.23",
         "is-deflate": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "semver": "^7.7.4",
+        "spdx-license-ids": "^3.0.23",
         "swagger-ui-react": "^5.32.6",
         "zod": "^4.4.3"
     },
@@ -57,6 +58,7 @@
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@types/semver": "^7.7.1",
+        "@types/spdx-license-ids": "^3.0.0",
         "@types/swagger-ui-react": "^5.18.0",
         "eslint": "^10.4.0",
         "eslint-config-prettier": "^10.1.8",

--- a/src/routes/library.page.tsx
+++ b/src/routes/library.page.tsx
@@ -1,0 +1,45 @@
+import { required } from '../utils/filter.ts';
+import Files from '../utils/jsx/islands/files.tsx';
+
+import type {
+    LibraryResponse,
+    LibraryVersionResponse,
+} from './library.schema.ts';
+
+/**
+ * /library/:version page component.
+ *
+ * @param props Page props.
+ * @param props.library Library data.
+ * @param props.version Library version data.
+ */
+export default ({
+    library,
+    version,
+}: {
+    library: LibraryResponse;
+    version: LibraryVersionResponse;
+}) => {
+    if (!required(library, 'name', 'description', 'version')) {
+        throw new Error('Library data is missing required fields');
+    }
+
+    if (!required(version, 'version', 'files', 'sri')) {
+        throw new Error('Library version data is missing required fields');
+    }
+
+    return (
+        <div>
+            <h1>{library.name}</h1>
+            <p>{library.description}</p>
+
+            <h2>Version {version.version}</h2>
+            <Files
+                name={library.name}
+                version={version.version}
+                files={version.files}
+                sri={version.sri}
+            />
+        </div>
+    );
+};

--- a/src/routes/library.page.tsx
+++ b/src/routes/library.page.tsx
@@ -199,6 +199,7 @@ export default ({
                 files={version.files}
                 sri={version.sri}
                 versions={library.versions}
+                featured={library.filename}
             />
         </>
     );

--- a/src/routes/library.page.tsx
+++ b/src/routes/library.page.tsx
@@ -1,10 +1,97 @@
+import { css } from '@emotion/css';
+import spdxLicenseIds from 'spdx-license-ids';
+
 import { required } from '../utils/filter.ts';
 import Files from '../utils/jsx/islands/files.tsx';
+import theme from '../utils/theme.ts';
 
 import type {
     LibraryResponse,
     LibraryVersionResponse,
 } from './library.schema.ts';
+
+const libraryRepo = (library: LibraryResponse) => {
+    const raw =
+        library.repository?.url ||
+        (library.autoupdate?.source === 'git'
+            ? library.autoupdate.target
+            : undefined);
+    if (!raw) return null;
+
+    const parsed = raw.match(
+        /^(?:https:\/\/|git@)?(?:www\.)?github\.com[:/]([^/]+)\/([^/]+)$/,
+    );
+    if (!parsed) return null;
+
+    const [, owner, name] = parsed;
+    if (!owner || !name) return null;
+
+    return {
+        owner,
+        name: name.replace(/\.git$/, ''),
+    };
+};
+
+const styles = {
+    header: css`
+        display: flex;
+        flex-direction: column;
+        gap: ${theme.spacing(2)};
+        margin: ${theme.spacing(-2, 0, 2)};
+        padding: ${theme.spacing(2, 0)};
+        position: relative;
+        isolation: isolate;
+        z-index: 1;
+
+        &::before {
+            content: '';
+            position: absolute;
+            width: 100vw;
+            left: 50%;
+            transform: translateX(-50%);
+            background: ${theme.background.header};
+            top: 0;
+            bottom: 0;
+            z-index: -1;
+        }
+    `,
+    row: css`
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: ${theme.spacing(1, 2)};
+    `,
+    name: css`
+        margin: 0;
+        font-size: ${theme.font.heading.size};
+        font-weight: ${theme.font.heading.weight};
+    `,
+    description: css`
+        margin: 0;
+        font-size: ${theme.font.large.size};
+        font-weight: ${theme.font.large.weight};
+    `,
+    link: css`
+        margin: 0;
+        font-size: ${theme.font.body.size};
+        font-weight: ${theme.font.body.weight};
+
+        a {
+            color: ${theme.text.brand};
+            text-decoration: underline;
+
+            &:hover {
+                text-decoration: none;
+            }
+        }
+    `,
+    keywords: css`
+        margin: 0;
+        font-size: ${theme.font.small.size};
+        font-weight: ${theme.font.small.weight};
+        color: ${theme.text.secondary};
+    `,
+};
 
 /**
  * /library/:version page component.
@@ -28,10 +115,83 @@ export default ({
         throw new Error('Library version data is missing required fields');
     }
 
+    const repo = libraryRepo(library);
+
     return (
-        <div>
-            <h1>{library.name}</h1>
-            <p>{library.description}</p>
+        <>
+            <div className={styles.header}>
+                <div className={styles.row}>
+                    <h1 className={styles.name}>{library.name}</h1>
+                    <p className={styles.description}>{library.description}</p>
+                </div>
+
+                <div className={styles.row}>
+                    {library.license && (
+                        <p className={styles.link}>
+                            {spdxLicenseIds.includes(library.license) ? (
+                                <a
+                                    href={`https://spdx.org/licenses/${encodeURIComponent(library.license)}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    {library.license}
+                                </a>
+                            ) : (
+                                library.license
+                            )}{' '}
+                            licensed
+                        </p>
+                    )}
+
+                    {library.autoupdate?.source === 'npm' && (
+                        <p className={styles.link}>
+                            <a
+                                href={`https://www.npmjs.com/package/${encodeURIComponent(library.autoupdate?.target)}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                npm package
+                            </a>
+                        </p>
+                    )}
+
+                    {repo && (
+                        <p className={styles.link}>
+                            <a
+                                href={`https://github.com/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                GitHub repository
+                            </a>
+                        </p>
+                    )}
+
+                    {library.homepage && (
+                        <p className={styles.link}>
+                            <a
+                                href={library.homepage}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                {library.homepage}
+                            </a>
+                        </p>
+                    )}
+                </div>
+
+                {!!library.keywords?.length && (
+                    <p className={styles.keywords}>
+                        Keywords:{' '}
+                        {library.keywords.map((keyword, index, arr) => (
+                            <span key={index}>
+                                {keyword}
+                                {index < arr.length - 1 && ', '}
+                            </span>
+                        ))}
+                    </p>
+                )}
+            </div>
 
             <h2>Version {version.version}</h2>
             <Files
@@ -40,6 +200,6 @@ export default ({
                 files={version.files}
                 sri={version.sri}
             />
-        </div>
+        </>
     );
 };

--- a/src/routes/library.page.tsx
+++ b/src/routes/library.page.tsx
@@ -107,7 +107,7 @@ export default ({
     library: LibraryResponse;
     version: LibraryVersionResponse;
 }) => {
-    if (!required(library, 'name', 'description', 'version')) {
+    if (!required(library, 'name', 'description', 'versions')) {
         throw new Error('Library data is missing required fields');
     }
 
@@ -193,12 +193,12 @@ export default ({
                 )}
             </div>
 
-            <h2>Version {version.version}</h2>
             <Files
                 name={library.name}
                 version={version.version}
                 files={version.files}
                 sri={version.sri}
+                versions={library.versions}
             />
         </>
     );

--- a/src/routes/library.spec.ts
+++ b/src/routes/library.spec.ts
@@ -537,7 +537,7 @@ describe('/libraries/:library', () => {
         describe('Requesting human response (?output=human)', () => {
             // Fetch the endpoint
             const path = '/libraries/backbone.js?output=human';
-            const response = beforeRequest(path);
+            const response = beforeRequest(path, { redirect: 'manual' });
 
             // Test the endpoint
             testCors(path, response);
@@ -546,7 +546,12 @@ describe('/libraries/:library', () => {
                     'public, max-age=21600',
                 ); // 6 hours
             });
-            testHuman(response);
+            it('returns a redirect to the latest version', () => {
+                expect(response.status).to.eq(302);
+                expect(response.headers.get('Location')).to.match(
+                    /^\/libraries\/backbone\.js\/[^/]+$/,
+                );
+            });
         });
 
         describe('Requesting a field (?fields=assets)', () => {

--- a/src/routes/library.ts
+++ b/src/routes/library.ts
@@ -15,6 +15,7 @@ import { queryCheck } from '../utils/query.ts';
 import respond, { isHuman, notFound, withCache } from '../utils/respond.ts';
 
 import { errorResponseSchema } from './errors.schema.ts';
+import LibraryPage from './library.page.tsx';
 import {
     type LibraryResponse,
     type LibraryVersionResponse,
@@ -130,7 +131,9 @@ const handleGetLibraryVersion = async (ctx: Context) => {
     withCache(ctx, 355 * 24 * 60 * 60, true);
 
     // Send the response
-    return respond<LibraryVersionResponse>(ctx, response);
+    return respond<LibraryVersionResponse>(ctx, response, ({ data }) =>
+        LibraryPage({ library: lib, version: data }),
+    );
 };
 
 /**

--- a/src/routes/library.ts
+++ b/src/routes/library.ts
@@ -2,6 +2,7 @@ import type { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import type { Context, Hono } from 'hono';
 import * as z from 'zod';
 
+import event from '../utils/event.ts';
 import files from '../utils/files.ts';
 import filter from '../utils/filter.ts';
 import {
@@ -11,7 +12,7 @@ import {
     libraryVersions,
 } from '../utils/metadata.ts';
 import { queryCheck } from '../utils/query.ts';
-import respond, { notFound, withCache } from '../utils/respond.ts';
+import respond, { isHuman, notFound, withCache } from '../utils/respond.ts';
 
 import { errorResponseSchema } from './errors.schema.ts';
 import {
@@ -238,6 +239,14 @@ const handleGetLibrary = async (ctx: Context) => {
 
     // Set a 6 hour life on this response
     withCache(ctx, 6 * 60 * 60);
+
+    // Redirect to the version endpoint if requesting a human-readable page
+    if (isHuman(ctx)) {
+        event('human-redirect', { ctx });
+        return ctx.redirect(
+            `/libraries/${lib.name}/${lib.version}?output=human`,
+        );
+    }
 
     // Send the response
     return respond<LibraryResponse>(ctx, response);

--- a/src/routes/library.ts
+++ b/src/routes/library.ts
@@ -131,9 +131,10 @@ const handleGetLibraryVersion = async (ctx: Context) => {
     withCache(ctx, 355 * 24 * 60 * 60, true);
 
     // Send the response
-    return respond<LibraryVersionResponse>(ctx, response, ({ data }) =>
-        LibraryPage({ library: lib, version: data }),
-    );
+    return respond<LibraryVersionResponse>(ctx, response, async ({ data }) => {
+        const versions = await libraryVersions(lib.name);
+        return LibraryPage({ library: { ...lib, versions }, version: data });
+    });
 };
 
 /**

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -11,3 +11,22 @@ export default <T extends Record<string, unknown>>(
     Object.fromEntries(
         Object.entries(source).filter(([key]) => filter(key)),
     ) as Partial<T>;
+
+/**
+ * Check that an object has the specified keys, and that they are not undefined. Useful for checking a filtered object has fields before accessing them.
+ *
+ * @param source Source object to check for required keys.
+ * @param keys Keys to check for in the source object.
+ */
+export const required = <
+    T extends object,
+    const K extends readonly Extract<keyof T, string>[],
+>(
+    source: T,
+    ...keys: K
+): source is T & Required<Pick<T, K[number]>> => {
+    for (const key of keys) {
+        if (source[key] === undefined) return false;
+    }
+    return true;
+};

--- a/src/utils/jsx/icons/check.tsx
+++ b/src/utils/jsx/icons/check.tsx
@@ -1,0 +1,20 @@
+// https://heroicons.com `check`
+
+const IconCheck = ({ className }: { className?: string }) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className={className}
+    >
+        <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="m4.5 12.75 6 6 9-13.5"
+        />
+    </svg>
+);
+
+export default IconCheck;

--- a/src/utils/jsx/icons/code.tsx
+++ b/src/utils/jsx/icons/code.tsx
@@ -1,0 +1,20 @@
+// https://heroicons.com `code-bracket`
+
+const IconCode = ({ className }: { className?: string }) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className={className}
+    >
+        <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
+        />
+    </svg>
+);
+
+export default IconCode;

--- a/src/utils/jsx/icons/link.tsx
+++ b/src/utils/jsx/icons/link.tsx
@@ -1,0 +1,20 @@
+// https://heroicons.com `link`
+
+const IconLink = ({ className }: { className?: string }) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className={className}
+    >
+        <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"
+        />
+    </svg>
+);
+
+export default IconLink;

--- a/src/utils/jsx/icons/shield.tsx
+++ b/src/utils/jsx/icons/shield.tsx
@@ -1,0 +1,20 @@
+// https://heroicons.com `shield-check`
+
+const IconShield = ({ className }: { className?: string }) => (
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className={className}
+    >
+        <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
+        />
+    </svg>
+);
+
+export default IconShield;

--- a/src/utils/jsx/islands/files.tsx
+++ b/src/utils/jsx/islands/files.tsx
@@ -1,7 +1,94 @@
+import { css } from '@emotion/css';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
-import { type CSSProperties, useLayoutEffect, useRef } from 'react';
+import { type CSSProperties, useLayoutEffect, useRef, useState } from 'react';
 
+import theme from '../../theme.ts';
 import createIsland from '../island.tsx';
+
+const styles = {
+    toolbar: css`
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: ${theme.spacing(1, 2)};
+    `,
+    url: css`
+        color: ${theme.text.secondary};
+        font-size: ${theme.font.small.size};
+        font-weight: ${theme.font.small.weight};
+        margin: 0 auto 0 0;
+    `,
+    dropdown: css`
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(0.5)};
+
+        label {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
+        select {
+            background: ${theme.background.navigation};
+            color: ${theme.text.primary};
+            cursor: pointer;
+            padding: ${theme.spacing(0.5, 1)};
+            font-size: ${theme.font.body.size};
+            font-weight: ${theme.font.body.weight};
+            border: none;
+            border-radius: ${theme.radius};
+            flex-shrink: 1;
+            min-width: ${theme.spacing(20)};
+            transition: color ${theme.transition};
+
+            &:hover {
+                color: ${theme.text.brand};
+            }
+        }
+    `,
+};
+
+const Versions = ({
+    name,
+    version,
+    versions,
+}: {
+    name: string;
+    version: string;
+    versions: string[];
+}) => {
+    const [selected, setSelected] = useState(version);
+    return (
+        <div className={styles.dropdown}>
+            <label htmlFor="version">Version:</label>
+            <select
+                id="version"
+                value={selected}
+                disabled={selected !== version}
+                onChange={(e) => {
+                    const changed = e.target.value;
+                    if (changed === selected) return;
+                    setSelected(changed);
+                    window.location.href = `/libraries/${encodeURIComponent(name)}/${encodeURIComponent(changed)}?output=human`;
+                }}
+            >
+                {versions.map((ver) => (
+                    <option key={ver} value={ver}>
+                        {ver}
+                    </option>
+                ))}
+            </select>
+        </div>
+    );
+};
 
 const File = ({
     name,
@@ -39,17 +126,20 @@ const File = ({
  * @param props.version Library version.
  * @param props.files List of files for the library version.
  * @param props.sri Map of file names to SRI hashes for the library version.
+ * @param props.versions List of all versions for the library.
  */
 const Files = ({
     name,
     version,
     files,
     sri,
+    versions,
 }: {
     name: string;
     version: string;
     files: string[];
     sri: Record<string, string>;
+    versions: string[];
 }) => {
     const listRef = useRef<HTMLUListElement | null>(null);
     const listOffsetRef = useRef(0);
@@ -66,34 +156,42 @@ const Files = ({
     });
 
     return (
-        <ul
-            ref={listRef}
-            style={{
-                height: `${virtualizer.getTotalSize()}px`,
-                position: 'relative',
-            }}
-        >
-            {virtualizer.getVirtualItems().map((item) => {
-                const file = files[item.index];
-                if (!file) return null;
+        <>
+            <div className={styles.toolbar}>
+                <code className={styles.url}>
+                    {`https://cdnjs.cloudflare.com/ajax/libs/${name}/${version}/...`}
+                </code>
+                <Versions name={name} version={version} versions={versions} />
+            </div>
+            <ul
+                ref={listRef}
+                style={{
+                    height: `${virtualizer.getTotalSize()}px`,
+                    position: 'relative',
+                }}
+            >
+                {virtualizer.getVirtualItems().map((item) => {
+                    const file = files[item.index];
+                    if (!file) return null;
 
-                return (
-                    <File
-                        key={file}
-                        name={name}
-                        version={version}
-                        file={file}
-                        sri={sri[file]}
-                        style={{
-                            position: 'absolute',
-                            top: 0,
-                            height: `${item.size}px`,
-                            transform: `translateY(${item.start - virtualizer.options.scrollMargin}px)`,
-                        }}
-                    />
-                );
-            })}
-        </ul>
+                    return (
+                        <File
+                            key={file}
+                            name={name}
+                            version={version}
+                            file={file}
+                            sri={sri[file]}
+                            style={{
+                                position: 'absolute',
+                                top: 0,
+                                height: `${item.size}px`,
+                                transform: `translateY(${item.start - virtualizer.options.scrollMargin}px)`,
+                            }}
+                        />
+                    );
+                })}
+            </ul>
+        </>
     );
 };
 

--- a/src/utils/jsx/islands/files.tsx
+++ b/src/utils/jsx/islands/files.tsx
@@ -1,7 +1,15 @@
 import { css } from '@emotion/css';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
-import { type CSSProperties, useLayoutEffect, useRef, useState } from 'react';
+import {
+    type CSSProperties,
+    useEffect,
+    useLayoutEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
 
+import fileTypes from '../../files.ts';
 import theme from '../../theme.ts';
 import createIsland from '../island.tsx';
 
@@ -90,6 +98,66 @@ const Versions = ({
     );
 };
 
+const Filter = ({
+    files,
+    onChange,
+}: {
+    files: string[];
+    onChange: (files: string[]) => void;
+}) => {
+    const [selected, setSelected] = useState<string>('');
+
+    const [types, mapped] = useMemo(() => {
+        const found = new Set<string>();
+        return [
+            found,
+            files.map((file) => {
+                const ext = file.split('.').slice(-1)[0] || '';
+                const type =
+                    ext in fileTypes
+                        ? fileTypes[ext as keyof typeof fileTypes]
+                        : 'Other';
+                found.add(type);
+                return { file, type };
+            }),
+        ];
+    }, [files]);
+
+    useEffect(() => {
+        if (!types.has(selected) || types.size <= 1) {
+            setSelected('');
+        }
+    }, [types, selected]);
+
+    useEffect(() => {
+        onChange(
+            selected === ''
+                ? mapped.map((x) => x.file)
+                : mapped.filter((x) => x.type === selected).map((x) => x.file),
+        );
+    }, [selected, mapped, onChange]);
+
+    if (types.size <= 1) return null;
+
+    return (
+        <div className={styles.dropdown}>
+            <label htmlFor="filter">Filter:</label>
+            <select
+                id="filter"
+                value={selected}
+                onChange={(e) => setSelected(e.target.value)}
+            >
+                <option value="">All assets</option>
+                {[...types].map((type) => (
+                    <option key={type} value={type}>
+                        {type}
+                    </option>
+                ))}
+            </select>
+        </div>
+    );
+};
+
 const File = ({
     name,
     version,
@@ -141,6 +209,7 @@ const Files = ({
     sri: Record<string, string>;
     versions: string[];
 }) => {
+    const [listFiles, setListFiles] = useState(files);
     const listRef = useRef<HTMLUListElement | null>(null);
     const listOffsetRef = useRef(0);
 
@@ -149,7 +218,7 @@ const Files = ({
     }, []);
 
     const virtualizer = useWindowVirtualizer({
-        count: files.length,
+        count: listFiles.length,
         estimateSize: () => 35,
         overscan: 5,
         scrollMargin: listOffsetRef.current,
@@ -162,6 +231,7 @@ const Files = ({
                     {`https://cdnjs.cloudflare.com/ajax/libs/${name}/${version}/...`}
                 </code>
                 <Versions name={name} version={version} versions={versions} />
+                <Filter files={files} onChange={setListFiles} />
             </div>
             <ul
                 ref={listRef}
@@ -171,7 +241,7 @@ const Files = ({
                 }}
             >
                 {virtualizer.getVirtualItems().map((item) => {
-                    const file = files[item.index];
+                    const file = listFiles[item.index];
                     if (!file) return null;
 
                     return (

--- a/src/utils/jsx/islands/files.tsx
+++ b/src/utils/jsx/islands/files.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import {
     type CSSProperties,
+    type ComponentType,
     useEffect,
     useLayoutEffect,
     useMemo,
@@ -93,6 +94,29 @@ const styles = {
     `,
     featured: css`
         outline: 2px solid ${theme.background.brand};
+    `,
+    buttons: css`
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(0.5)};
+        margin: 0 0 0 auto;
+    `,
+    copy: css`
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: ${theme.spacing(0.5)};
+        line-height: 0;
+        color: ${theme.text.primary};
+        transition: color ${theme.transition};
+
+        &:hover {
+            color: ${theme.text.brand};
+        }
+    `,
+    icon: css`
+        width: ${theme.spacing(2.5)};
+        height: ${theme.spacing(2.5)};
     `,
 };
 
@@ -190,6 +214,43 @@ const Filter = ({
     );
 };
 
+const Copy = ({
+    text,
+    label,
+    icon: Icon,
+}: {
+    text: string;
+    label: string;
+    icon: ComponentType<{ className?: string }>;
+}) => {
+    const [copied, setCopied] = useState(false);
+    const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const copy = () => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        if (timer.current) clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), 2000);
+    };
+
+    useEffect(
+        () => () => {
+            if (timer.current) clearTimeout(timer.current);
+        },
+        [],
+    );
+
+    return (
+        <button onClick={copy} title={label} className={styles.copy}>
+            {copied ? (
+                <IconCheck className={styles.icon} />
+            ) : (
+                <Icon className={styles.icon} />
+            )}
+        </button>
+    );
+};
+
 const File = ({
     name,
     version,
@@ -205,6 +266,8 @@ const File = ({
     featured?: boolean;
     style?: CSSProperties;
 }) => {
+    const integrity = sri ? ` integrity="${sri}" crossorigin="anonymous"` : '';
+
     return (
         <li
             style={style}
@@ -218,7 +281,41 @@ const File = ({
                 {file}
             </a>
 
-            {sri && <code style={{ marginLeft: '0.5em' }}>(SRI: {sri})</code>}
+            <div className={styles.buttons}>
+                <Copy
+                    text={`https://cdnjs.cloudflare.com/ajax/libs/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${file}`}
+                    label="Copy URL"
+                    icon={IconLink}
+                />
+
+                {file.endsWith('.js') && (
+                    <Copy
+                        text={`<script src="https://cdnjs.cloudflare.com/ajax/libs/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${file}"${integrity} referrerpolicy="no-referrer"></script>`}
+                        label="Copy <script> HTML"
+                        icon={IconCode}
+                    />
+                )}
+
+                {file.endsWith('mjs') && (
+                    <Copy
+                        text={`<script type="module" src="https://cdnjs.cloudflare.com/ajax/libs/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${file}"${integrity} referrerpolicy="no-referrer"></script>`}
+                        label="Copy <script type='module'> HTML"
+                        icon={IconCode}
+                    />
+                )}
+
+                {file.endsWith('.css') && (
+                    <Copy
+                        text={`<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${file}"${integrity} referrerpolicy="no-referrer">`}
+                        label="Copy <link> HTML"
+                        icon={IconCode}
+                    />
+                )}
+
+                {sri && (
+                    <Copy text={sri} label="Copy SRI hash" icon={IconShield} />
+                )}
+            </div>
         </li>
     );
 };

--- a/src/utils/jsx/islands/files.tsx
+++ b/src/utils/jsx/islands/files.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import {
     type CSSProperties,
@@ -11,6 +11,10 @@ import {
 
 import fileTypes from '../../files.ts';
 import theme from '../../theme.ts';
+import IconCheck from '../icons/check.tsx';
+import IconCode from '../icons/code.tsx';
+import IconLink from '../icons/link.tsx';
+import IconShield from '../icons/shield.tsx';
 import createIsland from '../island.tsx';
 
 const styles = {
@@ -61,6 +65,34 @@ const styles = {
                 color: ${theme.text.brand};
             }
         }
+    `,
+    list: css`
+        list-style: none;
+        padding: 0;
+        margin: ${theme.spacing(2, 0)};
+    `,
+    file: css`
+        width: 100%;
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(0.5)};
+        padding: ${theme.spacing(0.5, 1)};
+        background: ${theme.background.navigation};
+        border-radius: ${theme.radius};
+
+        a {
+            font-size: ${theme.font.body.size};
+            font-weight: ${theme.font.body.weight};
+            color: ${theme.text.brand};
+            text-decoration: underline;
+
+            &:hover {
+                text-decoration: none;
+            }
+        }
+    `,
+    featured: css`
+        outline: 2px solid ${theme.background.brand};
     `,
 };
 
@@ -163,16 +195,21 @@ const File = ({
     version,
     file,
     sri,
+    featured = false,
     style,
 }: {
     name: string;
     version: string;
     file: string;
     sri?: string;
+    featured?: boolean;
     style?: CSSProperties;
 }) => {
     return (
-        <li style={style}>
+        <li
+            style={style}
+            className={cx(styles.file, featured && styles.featured)}
+        >
             <a
                 href={`https://cdnjs.cloudflare.com/ajax/libs/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${file}`}
                 target="_blank"
@@ -195,6 +232,7 @@ const File = ({
  * @param props.files List of files for the library version.
  * @param props.sri Map of file names to SRI hashes for the library version.
  * @param props.versions List of all versions for the library.
+ * @param props.featured Featured file to highlight at the top of the list.
  */
 const Files = ({
     name,
@@ -202,14 +240,31 @@ const Files = ({
     files,
     sri,
     versions,
+    featured,
 }: {
     name: string;
     version: string;
     files: string[];
     sri: Record<string, string>;
     versions: string[];
+    featured?: string;
 }) => {
-    const [listFiles, setListFiles] = useState(files);
+    const sortedFiles = useMemo(
+        () =>
+            [...files].sort((a, b) => {
+                if (a === featured) return -1;
+                if (b === featured) return 1;
+
+                const aDepth = a.split('/').length;
+                const bDepth = b.split('/').length;
+                if (aDepth !== bDepth) return aDepth - bDepth;
+
+                return a.localeCompare(b);
+            }),
+        [files, featured],
+    );
+
+    const [listFiles, setListFiles] = useState(sortedFiles);
     const listRef = useRef<HTMLUListElement | null>(null);
     const listOffsetRef = useRef(0);
 
@@ -219,7 +274,8 @@ const Files = ({
 
     const virtualizer = useWindowVirtualizer({
         count: listFiles.length,
-        estimateSize: () => 35,
+        estimateSize: () => Number(theme.spacing(5).replace('px', '')),
+        gap: Number(theme.spacing(1).replace('px', '')),
         overscan: 5,
         scrollMargin: listOffsetRef.current,
     });
@@ -231,7 +287,7 @@ const Files = ({
                     {`https://cdnjs.cloudflare.com/ajax/libs/${name}/${version}/...`}
                 </code>
                 <Versions name={name} version={version} versions={versions} />
-                <Filter files={files} onChange={setListFiles} />
+                <Filter files={sortedFiles} onChange={setListFiles} />
             </div>
             <ul
                 ref={listRef}
@@ -239,6 +295,7 @@ const Files = ({
                     height: `${virtualizer.getTotalSize()}px`,
                     position: 'relative',
                 }}
+                className={styles.list}
             >
                 {virtualizer.getVirtualItems().map((item) => {
                     const file = listFiles[item.index];
@@ -251,6 +308,7 @@ const Files = ({
                             version={version}
                             file={file}
                             sri={sri[file]}
+                            featured={file === featured}
                             style={{
                                 position: 'absolute',
                                 top: 0,

--- a/src/utils/jsx/islands/files.tsx
+++ b/src/utils/jsx/islands/files.tsx
@@ -1,0 +1,100 @@
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
+import { type CSSProperties, useLayoutEffect, useRef } from 'react';
+
+import createIsland from '../island.tsx';
+
+const File = ({
+    name,
+    version,
+    file,
+    sri,
+    style,
+}: {
+    name: string;
+    version: string;
+    file: string;
+    sri?: string;
+    style?: CSSProperties;
+}) => {
+    return (
+        <li style={style}>
+            <a
+                href={`https://cdnjs.cloudflare.com/ajax/libs/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${file}`}
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                {file}
+            </a>
+
+            {sri && <code style={{ marginLeft: '0.5em' }}>(SRI: {sri})</code>}
+        </li>
+    );
+};
+
+/**
+ * Library version files island component to render all files on the CDN for a library version.
+ *
+ * @param props Component props.
+ * @param props.name Library name.
+ * @param props.version Library version.
+ * @param props.files List of files for the library version.
+ * @param props.sri Map of file names to SRI hashes for the library version.
+ */
+const Files = ({
+    name,
+    version,
+    files,
+    sri,
+}: {
+    name: string;
+    version: string;
+    files: string[];
+    sri: Record<string, string>;
+}) => {
+    const listRef = useRef<HTMLUListElement | null>(null);
+    const listOffsetRef = useRef(0);
+
+    useLayoutEffect(() => {
+        listOffsetRef.current = listRef.current?.offsetTop ?? 0;
+    }, []);
+
+    const virtualizer = useWindowVirtualizer({
+        count: files.length,
+        estimateSize: () => 35,
+        overscan: 5,
+        scrollMargin: listOffsetRef.current,
+    });
+
+    return (
+        <ul
+            ref={listRef}
+            style={{
+                height: `${virtualizer.getTotalSize()}px`,
+                position: 'relative',
+            }}
+        >
+            {virtualizer.getVirtualItems().map((item) => {
+                const file = files[item.index];
+                if (!file) return null;
+
+                return (
+                    <File
+                        key={file}
+                        name={name}
+                        version={version}
+                        file={file}
+                        sri={sri[file]}
+                        style={{
+                            position: 'absolute',
+                            top: 0,
+                            height: `${item.size}px`,
+                            transform: `translateY(${item.start - virtualizer.options.scrollMargin}px)`,
+                        }}
+                    />
+                );
+            })}
+        </ul>
+    );
+};
+
+export default createIsland(Files, 'files.tsx');

--- a/src/utils/respond.ts
+++ b/src/utils/respond.ts
@@ -73,6 +73,13 @@ export const withCache = (ctx: Context, age: number, immutable = false) => {
 };
 
 /**
+ * Check if the request is asking for human-readable output (HTML) instead of the regular JSON response.
+ *
+ * @param ctx Request context.
+ */
+export const isHuman = (ctx: Context) => ctx.req.query('output') === 'human';
+
+/**
  * Respond to a request with data, handling if it should be returned as JSON or pretty-printed in HTML.
  *
  * @param ctx Request context.
@@ -84,7 +91,7 @@ const respond = async <T = never>(
     data: NoInfer<T>,
     component: ComponentType<{ data: NoInfer<T> }> = Json,
 ) => {
-    if (ctx.req.query('output') === 'human') {
+    if (isHuman(ctx)) {
         event('human-output', { ctx });
         ctx.header('X-Robots-Tag', 'noindex');
 

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -11,6 +11,7 @@ export default {
     background: {
         body: '#454647',
         navigation: '#343535',
+        header: '#3a3c3c',
         footer: '#242525',
         brand: '#d9643a',
     },
@@ -26,6 +27,10 @@ export default {
         medium: breakpoint(96),
     },
     font: {
+        heading: {
+            size: '3rem',
+            weight: 600,
+        },
         large: {
             size: '1.25rem',
             weight: 400,


### PR DESCRIPTION
## Type of Change

- **Routes:** /libraries/:library + /libraries/:library/:version

## What issue does this relate to?

N/A

### What should this PR do?

Implements a dedicated HTML JSX page for library versions, with the ability to change library version, filter asset types, and copy individual assets.

### What are the acceptance criteria?

Library version human output works.