### PR TITLE
Support async JSX components

### DIFF
--- a/src/utils/respond.ts
+++ b/src/utils/respond.ts
@@ -2,7 +2,7 @@ import { cache } from '@emotion/css';
 import { env } from 'cloudflare:workers';
 import type { Context } from 'hono';
 import { type ComponentType, createElement } from 'react';
-import { renderToString } from 'react-dom/server';
+import { prerender } from 'react-dom/static';
 
 import type { ErrorResponse } from '../routes/errors.schema.ts';
 
@@ -89,13 +89,14 @@ const respond = async <T = never>(
         ctx.header('X-Robots-Tag', 'noindex');
 
         const Provider = await createIslandProvider();
-        const body = renderToString(
+        const { prelude } = await prerender(
             createElement(
                 Provider,
                 null,
                 createElement(Layout, null, createElement(component, { data })),
             ),
         );
+        const body = await new Response(prelude).text();
         const styles = getCriticalEmotionCss(body);
 
         return ctx.html(

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,7 @@
 name = "cdnjs-api-worker"
 main = "src/index.ts"
 send_metrics = false
-compatibility_date = "2022-10-31"
+compatibility_date = "2022-11-30"
 compatibility_flags = [ "nodejs_als" ]
 kv_namespaces = [ { binding = "CACHE" } ]
 


### PR DESCRIPTION
## Type of Change

- **Utilities:** Respond

## What issue does this relate to?

N/A

### What should this PR do?

Switches from the synchronous `renderToString` to the async `prerender` to support async JSX components being used.

### What are the acceptance criteria?

HTML human output continues to work.