### PR TITLE
Normalize autoupdate library prop

### DIFF
--- a/src/utils/metadata.schema.ts
+++ b/src/utils/metadata.schema.ts
@@ -30,6 +30,10 @@ export const librarySchema = z.object({
                 target: z.string(),
             }),
         ])
+        .transform((autoupdate) => ({
+            source: 'type' in autoupdate ? autoupdate.type : autoupdate.source,
+            target: autoupdate.target,
+        }))
         .optional(),
 });
 


### PR DESCRIPTION
## Type of Change


- **Routes:** /libraries/:library

## What issue does this relate to?

N/A

### What should this PR do?

Normalizes the structure for `library.autopdate`, removing the union type for `type`/`source`.

### What are the acceptance criteria?

`library.autoupdate` always has `source`, never `type`, if the object is present.