### PR TITLE
Update metadata base URL to metadata.cdnjs.cloudflare.com

### DIFF
--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -10,7 +10,7 @@ import {
 } from './metadata.schema.ts';
 import sortVersions from './sort.ts';
 
-const base = env.METADATA_BASE || 'https://metadata.speedcdnjs.com';
+const base = env.METADATA_BASE || 'https://metadata.cdnjs.cfdata.org';
 
 /**
  * Get a list of libraries.

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -10,7 +10,7 @@ import {
 } from './metadata.schema.ts';
 import sortVersions from './sort.ts';
 
-const base = env.METADATA_BASE || 'https://metadata.cdnjs.cfdata.org';
+const base = env.METADATA_BASE || 'https://metadata.cdnjs.cloudflare.com';
 
 /**
  * Get a list of libraries.


### PR DESCRIPTION
## Type of Change

- **Utilities:** `src/utils/metadata.ts` — updated the default metadata base URL

## What issue does this relate to?

<!-- Add issue reference here if applicable -->

### What should this PR do?

- Change the default `METADATA_BASE` URL from `https://metadata.speedcdnjs.com` to `https://metadata.cdnjs.cloudflare.com`

### What are the acceptance criteria?

- [x] Confirm the new metadata base URL (`https://metadata.cdnjs.cloudflare.com`) is reachable and serves the expected metadata
- [x] Verify that environments setting `METADATA_BASE` explicitly are unaffected (override behavior preserved)
- [x] Existing metadata-fetching routes continue to work against the new default

Metadata example requests 

https://metadata.cdnjs.cloudflare.com/packages
https://metadata.cdnjs.cloudflare.com/packages/jquery
https://metadata.cdnjs.cloudflare.com/packages/jquery/versions
https://metadata.cdnjs.cloudflare.com/packages/jquery/versions/3.7.1
https://metadata.cdnjs.cloudflare.com/packages/jquery/sris
https://metadata.cdnjs.cloudflare.com/packages/jquery/sris/3.7.1
https://metadata.cdnjs.cloudflare.com/packages/jquery/all