### PR TITLE
Change metadata base

### DIFF
--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -10,7 +10,7 @@ import {
 } from './metadata.schema.ts';
 import sortVersions from './sort.ts';
 
-const base = env.METADATA_BASE || 'https://metadata.speedcdnjs.com';
+const base = env.METADATA_BASE || 'https://metadata.cdnjs.cfdata.org';
 
 /**
  * Get a list of libraries.

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -10,7 +10,7 @@ import {
 } from './metadata.schema.ts';
 import sortVersions from './sort.ts';
 
-const base = env.METADATA_BASE || 'https://metadata.cdnjs.cfdata.org';
+const base = env.METADATA_BASE || 'https://metadata.cdnjs.cloudflare.com';
 
 /**
  * Get a list of libraries.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -51,7 +51,7 @@ head_sampling_rate = 1
 [env.staging.vars]
 DISABLE_LOGGING = true
 DISABLE_CACHING = false
-METADATA_BASE = ""
+METADATA_BASE = "https://metadata-staging.cdnjs.cloudflare.com"
 SENTRY_DSN = "" # Will be injected by build pipeline
 SENTRY_RELEASE = "" # Will be injected by build pipeline
 SENTRY_ENVIRONMENT = "staging"
@@ -72,7 +72,7 @@ head_sampling_rate = 0.05
 [env.production.vars]
 DISABLE_LOGGING = true
 DISABLE_CACHING = false
-METADATA_BASE = ""
+METADATA_BASE = "https://metadata.cdnjs.cloudflare.com"
 SENTRY_DSN = "" # Will be injected by build pipeline
 SENTRY_RELEASE = "" # Will be injected by build pipeline
 SENTRY_ENVIRONMENT = "production"


### PR DESCRIPTION
## Type of Change
- **Something else:** `wrangler.toml` — sets `METADATA_BASE` for staging and production.

## What issue does this relate to?
Follow-up to #230. That PR changed the dev-default metadata URL; this PR sets the explicit per-env values for the deployed workers.

### What should this PR do?
- Staging → `https://metadata-staging.cdnjs.cloudflare.com`
- Production → `https://metadata.cdnjs.cloudflare.com`

### What are the acceptance criteria?
- [x] Both hostnames resolve and serve metadata
- [x] `api.cdnjs.dev` library lookups work after staging deploy
- [x] `api.cdnjs.com` library lookups work after production deploy