### PR TITLE
Add page for about human output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import './utils/openapi.ts';
 
 import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 
+import aboutRoutes from './routes/about.ts';
 import apiRoutes from './routes/api.ts';
 import errorRoutes from './routes/errors.ts';
 import indexRoutes from './routes/index.ts';
@@ -25,6 +26,7 @@ app.use('*', cors(corsOptions));
 
 // Load the routes
 indexRoutes(app, registry);
+aboutRoutes(app, registry);
 apiRoutes(app, registry);
 statsRoutes(app, registry);
 whitelistRoutes(app, registry);

--- a/src/routes/about.page.tsx
+++ b/src/routes/about.page.tsx
@@ -1,0 +1,535 @@
+import { css } from '@emotion/css';
+
+import Header from '../utils/jsx/header.tsx';
+import sponsors from '../utils/sponsors.ts';
+import theme from '../utils/theme.ts';
+
+declare module 'csstype' {
+    // eslint-disable-next-line @typescript-eslint/consistent-indexed-object-style
+    interface Properties {
+        [index: `--${string}`]: string;
+    }
+}
+
+const styles = {
+    container: css`
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        max-width: ${theme.spacing(128)};
+        margin: 0 auto;
+        padding: ${theme.spacing(0, 0, 2)};
+    `,
+    stats: css`
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: ${theme.spacing(4)};
+        padding: ${theme.spacing(4, 0)};
+        margin: 0;
+        list-style: none;
+        position: relative;
+        isolation: isolate;
+        z-index: 1;
+
+        ${theme.breakpoints.medium} {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
+        &::before {
+            content: '';
+            position: absolute;
+            width: 100vw;
+            left: 50%;
+            transform: translateX(-50%);
+            background: ${theme.background.footer};
+            top: 0;
+            bottom: 0;
+            z-index: -1;
+        }
+    `,
+    stat: css`
+        display: flex;
+        flex-direction: column;
+        gap: ${theme.spacing(0.5)};
+        color: ${theme.text.secondary};
+        font-family: ${theme.font.families.mono};
+        font-size: ${theme.font.tiny.size};
+        font-weight: ${theme.font.tiny.weight};
+        text-align: center;
+        text-transform: uppercase;
+
+        strong {
+            display: block;
+            color: ${theme.text.primary};
+            font-family: ${theme.font.families.home};
+            font-size: ${theme.font.large.size};
+            font-weight: ${theme.font.large.weight};
+        }
+    `,
+    heading: css`
+        font-size: ${theme.font.large.size};
+        font-weight: ${theme.font.large.weight};
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(2)};
+        margin: 0;
+
+        &::after {
+            content: '';
+            flex-grow: 1;
+            height: ${theme.spacing(0.125)};
+            background: ${theme.text.primary};
+            margin: ${theme.spacing(0.25, 0, 0)};
+            opacity: 0.125;
+        }
+    `,
+    section: css`
+        margin: ${theme.spacing(4, 0, 0)};
+
+        p {
+            color: ${theme.text.secondary};
+            font-size: ${theme.font.body.size};
+            font-weight: ${theme.font.body.weight};
+            margin: ${theme.spacing(2, 0, 0)};
+
+            a {
+                color: ${theme.text.brand};
+                text-decoration: underline;
+
+                &:hover,
+                &:focus {
+                    text-decoration: none;
+                }
+            }
+        }
+    `,
+    split: css`
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: ${theme.spacing(4)};
+
+        ${theme.breakpoints.medium} {
+            grid-template-columns: 1fr;
+        }
+    `,
+    package: css`
+        background: ${theme.background.footer};
+        border-radius: ${theme.radius};
+        padding: ${theme.spacing(2)};
+        margin: ${theme.spacing(2, 0, 0)};
+        color: ${theme.text.secondary};
+        font-family: ${theme.font.families.mono};
+        font-size: ${theme.font.tiny.size};
+        font-weight: ${theme.font.tiny.weight};
+    `,
+    code: {
+        primary: css`
+            color: ${theme.text.brand};
+        `,
+        secondary: css`
+            color: rgb(from ${theme.text.brand} r g b / 0.5);
+        `,
+        hint: css`
+            color: rgb(from ${theme.text.secondary} r g b / 0.5);
+        `,
+    },
+    team: css`
+        background: ${theme.background.footer};
+        border-radius: ${theme.radius};
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: ${theme.spacing(1)};
+        padding: ${theme.spacing(2)};
+        margin: ${theme.spacing(2, 0, 0)};
+
+        p {
+            color: ${theme.text.secondary};
+            font-family: ${theme.font.families.mono};
+            font-size: ${theme.font.tiny.size};
+            font-weight: ${theme.font.tiny.weight};
+            margin: 0;
+        }
+
+        ul {
+            display: contents;
+            margin: 0;
+            padding: 0;
+            list-style: none;
+
+            a {
+                color: ${theme.text.brand};
+                text-decoration: underline;
+
+                &:hover,
+                &:focus {
+                    text-decoration: none;
+                }
+            }
+
+            div {
+                width: ${theme.spacing(0.5)};
+                height: ${theme.spacing(0.5)};
+                border-radius: 50%;
+                background: ${theme.background.body};
+            }
+        }
+    `,
+    sponsors: css`
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: ${theme.spacing(2)};
+        margin: ${theme.spacing(4, 0, 0)};
+        padding: 0;
+        list-style: none;
+
+        ${theme.breakpoints.medium} {
+            grid-template-columns: 1fr;
+        }
+
+        li {
+            display: flex;
+            flex-direction: column;
+            gap: ${theme.spacing(1)};
+            padding: ${theme.spacing(2)};
+            background: ${theme.background.footer};
+            border-radius: ${theme.radius};
+            position: relative;
+            isolation: isolate;
+            transition: background ${theme.transition};
+
+            &:has(a:hover, a:focus) {
+                background: rgb(from ${theme.background.footer} r g b / 0.75);
+            }
+
+            p {
+                margin: 0;
+
+                &,
+                small {
+                    font-size: ${theme.font.small.size};
+                    font-weight: ${theme.font.small.weight};
+                }
+
+                small {
+                    color: rgb(from ${theme.text.secondary} r g b / 0.5);
+                }
+            }
+
+            a {
+                color: ${theme.text.brand};
+                font-size: ${theme.font.large.size};
+                font-weight: ${theme.font.large.weight};
+                text-decoration: underline;
+
+                &:hover {
+                    text-decoration: none;
+                }
+
+                &::before {
+                    content: '';
+                    position: absolute;
+                    width: 100%;
+                    height: 100%;
+                    top: 0;
+                    left: 0;
+                }
+            }
+        }
+    `,
+};
+
+const pkg = [
+    <>
+        <span className={styles.code.hint}>packages/m/my-library.json</span>
+    </>,
+    '',
+    '{',
+    <>
+        {'  '}
+        <span className={styles.code.primary}>"name"</span>:{' '}
+        <span className={styles.code.secondary}>"my-library"</span>,
+    </>,
+    <>
+        {'  '}
+        <span className={styles.code.primary}>"filename"</span>:{' '}
+        <span className={styles.code.secondary}>"my-library.min.js"</span>,
+    </>,
+    <>
+        {'  '}
+        <span className={styles.code.hint}>...</span>
+    </>,
+    <>
+        {'  '}
+        <span className={styles.code.primary}>"autoupdate"</span>:{' {'}
+    </>,
+    <>
+        {'    '}
+        <span className={styles.code.primary}>"source"</span>:{' '}
+        <span className={styles.code.secondary}>"npm"</span>,
+    </>,
+    <>
+        {'    '}
+        <span className={styles.code.primary}>"target"</span>:{' '}
+        <span className={styles.code.secondary}>"my-library"</span>,
+    </>,
+    <>
+        {'    '}
+        <span className={styles.code.primary}>"fileMap"</span>: {'[{'}
+    </>,
+    <>
+        {'      '}
+        <span className={styles.code.primary}>"basePath"</span>:{' '}
+        <span className={styles.code.secondary}>"dist"</span>,
+    </>,
+    <>
+        {'      '}
+        <span className={styles.code.primary}>"files"</span>: [
+        <span className={styles.code.secondary}>"*.js"</span>]
+    </>,
+    <>
+        {'    '}
+        {'}]'}
+    </>,
+    <>
+        {'  '}
+        {'},'}
+    </>,
+    <>
+        {'  '}
+        <span className={styles.code.hint}>...</span>
+    </>,
+    '}',
+].flatMap((line, i) => (i === 0 ? [line] : ['\n', line]));
+
+/**
+ * /about page component.
+ */
+export default () => {
+    return (
+        <div className={styles.container}>
+            <Header
+                title={
+                    <>
+                        About <strong>cdnjs</strong>
+                    </>
+                }
+                prose={
+                    <>
+                        A free, open-source CDN for the web's most popular
+                        JavaScript, CSS, and font resources &mdash; globally
+                        cached on Cloudflare's network since 2011.
+                    </>
+                }
+            />
+
+            <ul className={styles.stats}>
+                <li className={styles.stat}>
+                    <strong>12.5%</strong> of all websites
+                </li>
+
+                <li className={styles.stat}>
+                    <strong>250B+</strong> Requests per month
+                </li>
+
+                <li className={styles.stat}>
+                    <strong>330+</strong> Edge locations
+                </li>
+
+                <li className={styles.stat}>
+                    <strong>2011</strong> Founded
+                </li>
+            </ul>
+
+            <div className={styles.section}>
+                <h2 className={styles.heading} id="what-is-cdnjs">
+                    What is cdnjs?
+                </h2>
+
+                <div className={styles.split}>
+                    <div>
+                        <p>
+                            cdnjs is a free, open-source, and community-driven
+                            CDN that makes it easy to include popular web
+                            libraries in any project &mdash; no build step, no
+                            npm install, just a single script or link tag.
+                        </p>
+
+                        <p>
+                            Launched in 2011, it is one of the longest-running
+                            public CDNs on the web. cdnjs believes in the power
+                            of open source, with all the package configurations
+                            and code behind the service available on GitHub.
+                        </p>
+
+                        <p>
+                            While a CDN isn't the right tool for every occasion,
+                            when it is, we're here for you (and your agent).
+                        </p>
+                    </div>
+
+                    <div>
+                        <p>
+                            Every file is served directly from Cloudflare's
+                            global network, ensuring fast response times for any
+                            assets included on your website, with full support
+                            for HTTP/3, HTTP/2, QUIC, and Brotli + GZIP
+                            compression.
+                        </p>
+
+                        <p>
+                            cdnjs is HSTS preloaded, ensuring all requests are
+                            securely served over HTTPS, and Subresource
+                            Integrity (SRI) hashes are provided for all script
+                            and link tags to provide an additional layer of
+                            security.
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div className={styles.section}>
+                <h2 className={styles.heading} id="adding-a-library">
+                    Adding a library
+                </h2>
+
+                <div className={styles.split}>
+                    <div>
+                        <p>
+                            cdnjs is different from some other public CDNs that
+                            support on-demand pull-through access to libraries.
+                            Instead, cdnjs is a curated CDN that only serves
+                            libraries that have been added to the service to by
+                            the community.
+                        </p>
+
+                        <p>
+                            Adding a library to cdnjs is straightforward: open a
+                            pull request to the{' '}
+                            <a
+                                href="https://github.com/cdnjs/packages"
+                                rel="noopener"
+                            >
+                                cdnjs/packages repository
+                            </a>{' '}
+                            with a small JSON file describing the library. Once
+                            approved and merged, cdnjs automation takes over —
+                            new versions are picked up automatically as they are
+                            published to npm or GitHub.
+                        </p>
+
+                        <p>
+                            No manual uploads for each version, no waiting for a
+                            maintainer to cut a release. The ingestion pipeline
+                            checks for updates regularly and handles
+                            minification, compression, SRI hash generation, and
+                            publishing to the CDN automatically.
+                        </p>
+                    </div>
+
+                    <div>
+                        <pre className={styles.package}>
+                            <code>{pkg}</code>
+                        </pre>
+                    </div>
+                </div>
+            </div>
+
+            <div className={styles.section}>
+                <h2 className={styles.heading} id="team">
+                    Team
+                </h2>
+
+                <div className={styles.team}>
+                    <p>Maintained by</p>
+                    <div />
+                    <ul>
+                        <li>
+                            <a
+                                href="https://github.com/MattIPv4"
+                                rel="noopener"
+                                title="@MattIPv4"
+                            >
+                                Matt Cowley
+                            </a>
+                        </li>
+                        <div />
+                        <li>
+                            <a
+                                href="https://blog.cloudflare.com/tag/cdnjs"
+                                rel="noopener"
+                            >
+                                Cloudflare Engineering
+                            </a>
+                        </li>
+                        <div />
+                        <li>
+                            <a href="https://github.com/cdnjs" rel="noopener">
+                                You?
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+
+                <div className={styles.team}>
+                    <p>Founded by</p>
+                    <div />
+                    <ul>
+                        <li>
+                            <a
+                                href="https://github.com/ryankirkman"
+                                rel="noopener"
+                                title="@ryankirkman"
+                            >
+                                Ryan Kirkman
+                            </a>
+                        </li>
+                        <div />
+                        <li>
+                            <a
+                                href="https://github.com/thomasdavis"
+                                rel="noopener"
+                                title="@thomasdavis"
+                            >
+                                Thomas Davis
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className={styles.section}>
+                <h2 className={styles.heading} id="sponsors">
+                    Sponsors
+                </h2>
+
+                <p>
+                    cdnjs is free to use because of the generosity of these
+                    organisations. Their support covers infrastructure, tooling,
+                    and monitoring.
+                </p>
+
+                <ul className={styles.sponsors}>
+                    {sponsors.map((sponsor) => (
+                        <li key={sponsor.name}>
+                            <p>
+                                <a href={sponsor.url('about')} rel="noopener">
+                                    {sponsor.name}
+                                </a>
+                            </p>
+
+                            {sponsor.message ? (
+                                <p>{sponsor.message}</p>
+                            ) : (
+                                <p>
+                                    <small>{sponsor.service}</small>
+                                </p>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </div>
+    );
+};

--- a/src/routes/about.spec.ts
+++ b/src/routes/about.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import testCors from '../utils/spec/cors.ts';
+import { beforeRequest, request } from '../utils/spec/request.ts';
+
+describe('/about', () => {
+    // Fetch the endpoint
+    const path = '/about';
+    const response = beforeRequest(path, { redirect: 'manual' });
+
+    // Test the endpoint
+    testCors(path, response);
+    it('returns the correct Cache headers', () => {
+        expect(response.headers.get('Cache-Control')).to.eq(
+            'public, max-age=30672000, immutable',
+        ); // 355 days
+    });
+    it('redirects to the cdnjs.com about page as a 301', () => {
+        expect(response.status).to.eq(301);
+        expect(response.headers.get('Location')).to.eq(
+            'https://cdnjs.com/about',
+        );
+    });
+
+    // Test with a trailing slash
+    it('responds to requests with a trailing slash', async () => {
+        const res = await request(path + '/', { redirect: 'manual' });
+        expect(res.status).to.eq(301);
+        expect(res.headers.get('Location')).to.eq('https://cdnjs.com/about');
+    });
+});

--- a/src/routes/about.ts
+++ b/src/routes/about.ts
@@ -1,0 +1,30 @@
+import type { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import type { Context, Hono } from 'hono';
+
+import { withCache } from '../utils/respond.ts';
+
+/**
+ * Handle GET /about requests.
+ *
+ * @param ctx Request context.
+ */
+const handleGetAbout = (ctx: Context) => {
+    // Set a 355 day (same as CDN) life on this response
+    // This is also immutable
+    withCache(ctx, 355 * 24 * 60 * 60, true);
+
+    // Redirect to the about page
+    return ctx.redirect('https://cdnjs.com/about', 301);
+};
+
+/**
+ * Register about routes.
+ *
+ * @param app App instance.
+ * @param _registry OpenAPI registry instance.
+ */
+export default (app: Hono, _registry: OpenAPIRegistry) => {
+    // Redirect to the about page
+    app.get('/about', handleGetAbout);
+    app.get('/about/', handleGetAbout);
+};

--- a/src/routes/about.ts
+++ b/src/routes/about.ts
@@ -1,7 +1,9 @@
 import type { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
 import type { Context, Hono } from 'hono';
 
-import { withCache } from '../utils/respond.ts';
+import respond, { isHuman, withCache } from '../utils/respond.ts';
+
+import AboutPage from './about.page.tsx';
 
 /**
  * Handle GET /about requests.
@@ -9,6 +11,14 @@ import { withCache } from '../utils/respond.ts';
  * @param ctx Request context.
  */
 const handleGetAbout = (ctx: Context) => {
+    // Render a human-readable page
+    if (isHuman(ctx)) {
+        // Set a 6 hour life on this response
+        withCache(ctx, 6 * 60 * 60);
+
+        return respond<undefined>(ctx, undefined, AboutPage);
+    }
+
     // Set a 355 day (same as CDN) life on this response
     // This is also immutable
     withCache(ctx, 355 * 24 * 60 * 60, true);

--- a/src/routes/index.page.tsx
+++ b/src/routes/index.page.tsx
@@ -1,95 +1,10 @@
 import { css } from '@emotion/css';
 
-import Grid from '../utils/jsx/grid.tsx';
+import Header from '../utils/jsx/header.tsx';
 import Typeahead from '../utils/jsx/islands/typeahead.tsx';
 import theme from '../utils/theme.ts';
 
 const styles = {
-    background: css`
-        color: ${theme.background.brand};
-        position: absolute;
-        width: 100vw;
-        height: 100%;
-        left: 50%;
-        transform: translateX(-50%);
-        top: 0;
-        bottom: 0;
-        z-index: -1;
-    `,
-    content: css`
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        text-align: center;
-        gap: ${theme.spacing(4)};
-        margin: auto;
-        max-width: 100%;
-        background: radial-gradient(
-            ellipse at center,
-            rgb(from ${theme.background.body} r g b / 0.9) 0%,
-            rgb(from ${theme.background.body} r g b / 0) 100%
-        );
-        padding: ${theme.spacing(4, 2)};
-    `,
-    badge: css`
-        display: flex;
-        align-items: center;
-        gap: ${theme.spacing(1.5)};
-        background: rgb(from ${theme.background.brand} r g b / 0.125);
-        border: ${theme.spacing(0.125)} solid
-            rgb(from ${theme.background.brand} r g b / 0.75);
-        border-radius: ${theme.spacing(4)};
-        color: ${theme.text.brand};
-        font-family: ${theme.font.families.mono};
-        font-size: ${theme.font.tiny.size};
-        font-weight: ${theme.font.tiny.weight};
-        line-height: 1;
-        text-transform: uppercase;
-        padding: ${theme.spacing(1, 1.75)};
-        margin: 0;
-
-        &::before {
-            content: ' ';
-            display: block;
-            width: ${theme.spacing(0.75)};
-            height: ${theme.spacing(0.75)};
-            margin: 0 ${theme.spacing(-0.25)};
-            border-radius: 50%;
-            background: ${theme.text.brand};
-            box-shadow: 0 0 ${theme.spacing(0.75)} ${theme.text.brand};
-        }
-    `,
-    title: css`
-        font-family: ${theme.font.families.home};
-        line-height: 1.125;
-        margin: 0;
-
-        &,
-        strong {
-            font-size: ${theme.font.heading.size};
-            font-weight: ${theme.font.heading.weight};
-        }
-
-        strong {
-            color: ${theme.text.brand};
-        }
-    `,
-    prose: css`
-        color: ${theme.text.secondary};
-        line-height: 1.5;
-        margin: 0;
-
-        &,
-        strong {
-            font-size: ${theme.font.small.size};
-            font-weight: ${theme.font.small.weight};
-        }
-
-        strong {
-            color: ${theme.text.primary};
-        }
-    `,
     search: css`
         width: ${theme.spacing(80)};
         max-width: 100%;
@@ -103,26 +18,24 @@ const styles = {
  */
 export default () => {
     return (
-        <>
-            <Grid className={styles.background} />
-
-            <div className={styles.content}>
-                <p className={styles.badge}>Powered by Cloudflare</p>
-
-                <h1 className={styles.title}>
+        <Header
+            title={
+                <>
                     The free CDN for
                     <br /> <strong>open source libraries.</strong>
-                </h1>
-
-                <p className={styles.prose}>
+                </>
+            }
+            prose={
+                <>
                     JavaScript, CSS, and font resources, globally cached on
                     Cloudflare's network.
                     <br /> Trusted by <strong>12.5% of all websites</strong>,
                     serving <strong>250 billion requests per month</strong>.
-                </p>
-
-                <Typeahead className={styles.search} />
-            </div>
-        </>
+                </>
+            }
+            fill
+        >
+            <Typeahead className={styles.search} />
+        </Header>
     );
 };

--- a/src/utils/jsx/footer.tsx
+++ b/src/utils/jsx/footer.tsx
@@ -1,6 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { Fragment } from 'react';
 
+import sponsors from '../sponsors.ts';
 import theme from '../theme.ts';
 
 import Logo from './logo.tsx';
@@ -142,14 +143,10 @@ const sections: Section[][] = [
     [
         {
             title: 'Sponsors',
-            links: [
-                { label: 'Cloudflare', href: 'https://www.cloudflare.com' },
-                { label: 'Algolia', href: 'https://www.algolia.com' },
-                { label: 'DigitalOcean', href: 'https://www.digitalocean.com' },
-                { label: 'Statuspage', href: 'https://www.statuspage.io' },
-                { label: 'Sentry', href: 'https://sentry.io' },
-                { label: 'UptimeRobot', href: 'https://uptimerobot.com' },
-            ],
+            links: sponsors.map((sponsor) => ({
+                label: sponsor.name,
+                href: sponsor.url('footer'),
+            })),
         },
     ],
 ];

--- a/src/utils/jsx/grid.tsx
+++ b/src/utils/jsx/grid.tsx
@@ -189,12 +189,24 @@ const styles = {
  * Homepage grid background
  *
  * @param props Component props.
+ * @param props.width The number of columns to display in the grid.
+ * @param props.height The number of rows to display in the grid.
  * @param props.className Optional additional class name(s) to apply to the logo.
  */
-export default ({ className }: { className?: string }) => (
+export default ({
+    width = cols,
+    height = rows,
+    className,
+}: {
+    width?: number;
+    height?: number;
+    className?: string;
+}) => (
     <svg
         xmlns="http://www.w3.org/2000/svg"
-        viewBox={`0 0 ${cols * size} ${rows * size}`}
+        // The base viewBox would be `0 0 ${cols * size} ${rows * size}`
+        // But, we want to center that around whatever width and height are passed in
+        viewBox={`${(cols * size - width * size) / 2} ${(rows * size - height * size) / 2} ${width * size} ${height * size}`}
         preserveAspectRatio="xMidYMid slice"
         aria-hidden="true"
         className={className}

--- a/src/utils/jsx/header.tsx
+++ b/src/utils/jsx/header.tsx
@@ -1,0 +1,140 @@
+import { css, cx } from '@emotion/css';
+import type { ReactNode } from 'react';
+
+import theme from '../theme.ts';
+
+import Grid from './grid.tsx';
+
+const styles = {
+    header: css`
+        position: relative;
+        display: flex;
+        flex-direction: column;
+    `,
+    fill: css`
+        flex-grow: 1;
+    `,
+    background: css`
+        color: ${theme.background.brand};
+        position: absolute;
+        width: 100vw;
+        height: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        top: 0;
+        bottom: 0;
+        z-index: -1;
+    `,
+    content: css`
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        gap: ${theme.spacing(4)};
+        margin: auto;
+        max-width: 100%;
+        background: radial-gradient(
+            ellipse at center,
+            rgb(from ${theme.background.body} r g b / 0.9) 0%,
+            rgb(from ${theme.background.body} r g b / 0) 100%
+        );
+        padding: ${theme.spacing(4, 2)};
+    `,
+    badge: css`
+        display: flex;
+        align-items: center;
+        gap: ${theme.spacing(1.5)};
+        background: rgb(from ${theme.background.brand} r g b / 0.125);
+        border: ${theme.spacing(0.125)} solid
+            rgb(from ${theme.background.brand} r g b / 0.75);
+        border-radius: ${theme.spacing(4)};
+        color: ${theme.text.brand};
+        font-family: ${theme.font.families.mono};
+        font-size: ${theme.font.tiny.size};
+        font-weight: ${theme.font.tiny.weight};
+        line-height: 1;
+        text-transform: uppercase;
+        padding: ${theme.spacing(1, 1.75)};
+        margin: 0;
+        opacity: 0.875;
+
+        &::before {
+            content: ' ';
+            display: block;
+            width: ${theme.spacing(0.75)};
+            height: ${theme.spacing(0.75)};
+            margin: 0 ${theme.spacing(-0.25)};
+            border-radius: 50%;
+            background: ${theme.text.brand};
+            box-shadow: 0 0 ${theme.spacing(0.75)} ${theme.text.brand};
+        }
+    `,
+    title: css`
+        font-family: ${theme.font.families.home};
+        line-height: 1.125;
+        margin: 0;
+
+        &,
+        strong {
+            font-size: ${theme.font.heading.size};
+            font-weight: ${theme.font.heading.weight};
+        }
+
+        strong {
+            color: ${theme.text.brand};
+        }
+    `,
+    prose: css`
+        color: ${theme.text.secondary};
+        line-height: 1.5;
+        margin: 0;
+
+        &,
+        strong {
+            font-size: ${theme.font.small.size};
+            font-weight: ${theme.font.small.weight};
+        }
+
+        strong {
+            color: ${theme.text.primary};
+        }
+    `,
+};
+
+/**
+ * Standard cdnjs HTML layout for the page header.
+ *
+ * @param props Component props.
+ * @param props.title The title of the page.
+ * @param props.prose The prose content of the page.
+ * @param props.fill If the header should grow to fill the parent.
+ * @param props.children Optional additional content to render in the header.
+ */
+export default ({
+    title,
+    prose,
+    fill,
+    children,
+}: {
+    title: ReactNode;
+    prose: ReactNode;
+    fill?: boolean;
+    children?: ReactNode;
+}) => {
+    return (
+        <div className={cx(styles.header, fill && styles.fill)}>
+            <Grid className={styles.background} height={fill ? undefined : 3} />
+
+            <div className={styles.content}>
+                <p className={styles.badge}>Powered by Cloudflare</p>
+
+                <h1 className={styles.title}>{title}</h1>
+
+                <p className={styles.prose}>{prose}</p>
+
+                {children}
+            </div>
+        </div>
+    );
+};

--- a/src/utils/jsx/islands/libraries.tsx
+++ b/src/utils/jsx/islands/libraries.tsx
@@ -99,6 +99,11 @@ const styles = {
         border-radius: ${theme.radius};
         position: relative;
         isolation: isolate;
+        transition: background ${theme.transition};
+
+        &:has(a:hover, a:focus) {
+            background: rgb(from ${theme.background.footer} r g b / 0.75);
+        }
     `,
     name: css`
         display: flex;

--- a/src/utils/sponsors.ts
+++ b/src/utils/sponsors.ts
@@ -1,0 +1,55 @@
+interface Sponsor {
+    name: string;
+    service: string;
+    url: (context: string) => string;
+    message?: string;
+}
+
+const sponsors: Sponsor[] = [
+    {
+        name: 'Cloudflare',
+        service: 'Supporting cdnjs with core infrastructure and CDN services.',
+        url: (context) =>
+            `https://www.cloudflare.com?utm_source=cdnjs&utm_medium=cdnjs_link&utm_campaign=cdnjs_${context}`,
+        message:
+            'Believing cdnjs is part of the open-source community-driven tools that will build the future of the internet, Cloudflare supports cdnjs by providing the global CDN infrastructure and project maintenance.',
+    },
+    {
+        name: 'Algolia',
+        service: 'Supporting cdnjs with search indexing services.',
+        url: (context) =>
+            `https://www.algolia.com?utm_source=cdnjs&utm_medium=cdnjs_link&utm_campaign=cdnjs_${context}`,
+        message:
+            "Algolia provides a developer-friendly SaaS API for searching. With Algolia's search indexing and unique find as you type experience, you can find cdnjs libraries in just a few key strokes.",
+    },
+    {
+        name: 'DigitalOcean',
+        service: 'Supporting cdnjs with cloud infrastructure services.',
+        url: (context) =>
+            `https://www.digitalocean.com?utm_source=cdnjs&utm_medium=cdnjs_link&utm_campaign=cdnjs_${context}`,
+        message:
+            'DigitalOcean is simplifying the cloud by providing an infrastructure experience that developers love. DigitalOcean is proud to give back to open-source and community-driven projects like cdnjs.',
+    },
+    {
+        name: 'Statuspage',
+        service: 'Supporting cdnjs with incident communication services.',
+        url: (context) =>
+            `https://www.atlassian.com/software/statuspage?utm_source=cdnjs&utm_medium=cdnjs_link&utm_campaign=cdnjs_${context}`,
+    },
+    {
+        name: 'Sentry',
+        service: 'Supporting cdnjs with error monitoring services.',
+        url: (context) =>
+            `https://sentry.io?utm_source=cdnjs&utm_medium=cdnjs_link&utm_campaign=cdnjs_${context}`,
+    },
+    {
+        name: 'UptimeRobot',
+        service: 'Supporting cdnjs with uptime monitoring services.',
+        url: (context) =>
+            `https://uptimerobot.com?utm_source=cdnjs&utm_medium=cdnjs_link&utm_campaign=cdnjs_${context}`,
+        message:
+            "UptimeRobot is the world's leading uptime monitoring service, supporting cdnjs to ensure the service is always available for developers and users around the world.",
+    },
+];
+
+export default sponsors;


### PR DESCRIPTION
## Type of Change

- **Routes:** /about

## What issue does this relate to?

N/A

### What should this PR do?

Implements a dedicated HTML JSX page for about, with a redirect to the site if accessed from the API.

### What are the acceptance criteria?

About human output works.