### PR TITLE
Use header component across all human output pages

### DIFF
--- a/src/routes/about.page.tsx
+++ b/src/routes/about.page.tsx
@@ -24,27 +24,12 @@ const styles = {
         display: grid;
         grid-template-columns: repeat(4, minmax(0, 1fr));
         gap: ${theme.spacing(4)};
-        padding: ${theme.spacing(4, 0)};
+        padding: ${theme.spacing(2, 0)};
         margin: 0;
         list-style: none;
-        position: relative;
-        isolation: isolate;
-        z-index: 1;
 
         ${theme.breakpoints.medium} {
             grid-template-columns: repeat(2, minmax(0, 1fr));
-        }
-
-        &::before {
-            content: '';
-            position: absolute;
-            width: 100vw;
-            left: 50%;
-            transform: translateX(-50%);
-            background: ${theme.background.footer};
-            top: 0;
-            bottom: 0;
-            z-index: -1;
         }
     `,
     stat: css`
@@ -315,32 +300,25 @@ export default () => {
                         About <strong>cdnjs</strong>
                     </>
                 }
-                prose={
-                    <>
-                        A free, open-source CDN for the web's most popular
-                        JavaScript, CSS, and font resources &mdash; globally
-                        cached on Cloudflare's network since 2011.
-                    </>
-                }
-            />
+            >
+                <ul className={styles.stats}>
+                    <li className={styles.stat}>
+                        <strong>12.5%</strong> of all websites
+                    </li>
 
-            <ul className={styles.stats}>
-                <li className={styles.stat}>
-                    <strong>12.5%</strong> of all websites
-                </li>
+                    <li className={styles.stat}>
+                        <strong>250B+</strong> Requests per month
+                    </li>
 
-                <li className={styles.stat}>
-                    <strong>250B+</strong> Requests per month
-                </li>
+                    <li className={styles.stat}>
+                        <strong>330+</strong> Edge locations
+                    </li>
 
-                <li className={styles.stat}>
-                    <strong>330+</strong> Edge locations
-                </li>
-
-                <li className={styles.stat}>
-                    <strong>2011</strong> Founded
-                </li>
-            </ul>
+                    <li className={styles.stat}>
+                        <strong>2011</strong> Founded
+                    </li>
+                </ul>
+            </Header>
 
             <div className={styles.section}>
                 <h2 className={styles.heading} id="what-is-cdnjs">

--- a/src/routes/about.page.tsx
+++ b/src/routes/about.page.tsx
@@ -98,7 +98,7 @@ const styles = {
         }
     `,
     package: css`
-        background: ${theme.background.footer};
+        background: ${theme.background.elevated};
         border-radius: ${theme.radius};
         padding: ${theme.spacing(2)};
         margin: ${theme.spacing(2, 0, 0)};
@@ -119,7 +119,7 @@ const styles = {
         `,
     },
     team: css`
-        background: ${theme.background.footer};
+        background: ${theme.background.elevated};
         border-radius: ${theme.radius};
         display: flex;
         flex-direction: row;
@@ -157,7 +157,7 @@ const styles = {
                 width: ${theme.spacing(0.5)};
                 height: ${theme.spacing(0.5)};
                 border-radius: 50%;
-                background: ${theme.background.body};
+                background: ${theme.background.primary};
             }
         }
     `,
@@ -178,14 +178,14 @@ const styles = {
             flex-direction: column;
             gap: ${theme.spacing(1)};
             padding: ${theme.spacing(2)};
-            background: ${theme.background.footer};
+            background: ${theme.background.elevated};
             border-radius: ${theme.radius};
             position: relative;
             isolation: isolate;
             transition: background ${theme.transition};
 
             &:has(a:hover, a:focus) {
-                background: rgb(from ${theme.background.footer} r g b / 0.75);
+                background: rgb(from ${theme.background.elevated} r g b / 0.75);
             }
 
             p {

--- a/src/routes/api.page.tsx
+++ b/src/routes/api.page.tsx
@@ -24,7 +24,7 @@ const styles = {
         }
 
         code {
-            background: ${theme.background.body};
+            background: ${theme.background.primary};
             border-radius: ${theme.radius};
             color: ${theme.text.primary};
             font-family: ${theme.font.families.mono};

--- a/src/routes/api.page.tsx
+++ b/src/routes/api.page.tsx
@@ -1,6 +1,41 @@
+import { css } from '@emotion/css';
+
+import Header from '../utils/jsx/header.tsx';
 import Swagger from '../utils/jsx/islands/swagger.tsx';
+import theme from '../utils/theme.ts';
 
 import type { OpenApiResponse } from './api.schema.ts';
+
+const styles = {
+    header: css`
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: ${theme.spacing(2)};
+        padding: ${theme.spacing(2, 0)};
+
+        p {
+            color: ${theme.text.secondary};
+            font-family: ${theme.font.families.mono};
+            font-size: ${theme.font.tiny.size};
+            font-weight: ${theme.font.tiny.weight};
+            text-transform: uppercase;
+            margin: 0;
+        }
+
+        code {
+            background: ${theme.background.body};
+            border-radius: ${theme.radius};
+            color: ${theme.text.primary};
+            font-family: ${theme.font.families.mono};
+            font-size: ${theme.font.small.size};
+            font-weight: ${theme.font.small.weight};
+            text-transform: none;
+            padding: ${theme.spacing(0.5, 1)};
+            margin: ${theme.spacing(0, 0.25)};
+        }
+    `,
+};
 
 /**
  * /api page component.
@@ -8,4 +43,25 @@ import type { OpenApiResponse } from './api.schema.ts';
  * @param props Page props.
  * @param props.data OpenAPI response data.
  */
-export default ({ data }: { data: OpenApiResponse }) => <Swagger spec={data} />;
+export default ({ data }: { data: OpenApiResponse }) => {
+    return (
+        <>
+            <Header
+                title={
+                    <>
+                        Query <strong>cdnjs</strong>
+                    </>
+                }
+            >
+                <div className={styles.header}>
+                    <p>
+                        Base URL <code>https://api.cdnjs.com</code>
+                    </p>
+                    <p>No authentication required</p>
+                </div>
+            </Header>
+
+            <Swagger spec={data} />
+        </>
+    );
+};

--- a/src/routes/index.page.tsx
+++ b/src/routes/index.page.tsx
@@ -8,8 +8,6 @@ const styles = {
     search: css`
         width: ${theme.spacing(80)};
         max-width: 100%;
-        border-radius: ${theme.radius};
-        box-shadow: 0 0 ${theme.spacing(2)} ${theme.background.footer};
     `,
 };
 
@@ -34,8 +32,7 @@ export default () => {
                 </>
             }
             fill
-        >
-            <Typeahead className={styles.search} />
-        </Header>
+            extra={<Typeahead className={styles.search} />}
+        />
     );
 };

--- a/src/routes/library.page.tsx
+++ b/src/routes/library.page.tsx
@@ -2,6 +2,8 @@ import { css } from '@emotion/css';
 import spdxLicenseIds from 'spdx-license-ids';
 
 import { required } from '../utils/filter.ts';
+import Header from '../utils/jsx/header.tsx';
+import File from '../utils/jsx/islands/file.tsx';
 import Files from '../utils/jsx/islands/files.tsx';
 import theme from '../utils/theme.ts';
 
@@ -119,79 +121,95 @@ export default ({
 
     return (
         <>
-            <div className={styles.header}>
-                <div className={styles.row}>
-                    <h1 className={styles.name}>{library.name}</h1>
-                    <p className={styles.description}>{library.description}</p>
-                </div>
+            <Header
+                title={
+                    <>
+                        <strong>{library.name}</strong>{' '}
+                        <small>{library.version}</small>
+                    </>
+                }
+                prose={library.description}
+                extra={
+                    <>
+                        <div className={styles.row}>
+                            {library.license && (
+                                <p className={styles.link}>
+                                    {spdxLicenseIds.includes(
+                                        library.license,
+                                    ) ? (
+                                        <a
+                                            href={`https://spdx.org/licenses/${encodeURIComponent(library.license)}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                        >
+                                            {library.license}
+                                        </a>
+                                    ) : (
+                                        library.license
+                                    )}{' '}
+                                    licensed
+                                </p>
+                            )}
 
-                <div className={styles.row}>
-                    {library.license && (
-                        <p className={styles.link}>
-                            {spdxLicenseIds.includes(library.license) ? (
-                                <a
-                                    href={`https://spdx.org/licenses/${encodeURIComponent(library.license)}`}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                >
-                                    {library.license}
-                                </a>
-                            ) : (
-                                library.license
-                            )}{' '}
-                            licensed
-                        </p>
-                    )}
+                            {library.autoupdate?.source === 'npm' && (
+                                <p className={styles.link}>
+                                    <a
+                                        href={`https://www.npmjs.com/package/${encodeURIComponent(library.autoupdate?.target)}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        npm package
+                                    </a>
+                                </p>
+                            )}
 
-                    {library.autoupdate?.source === 'npm' && (
-                        <p className={styles.link}>
-                            <a
-                                href={`https://www.npmjs.com/package/${encodeURIComponent(library.autoupdate?.target)}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                npm package
-                            </a>
-                        </p>
-                    )}
+                            {repo && (
+                                <p className={styles.link}>
+                                    <a
+                                        href={`https://github.com/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        GitHub repository
+                                    </a>
+                                </p>
+                            )}
 
-                    {repo && (
-                        <p className={styles.link}>
-                            <a
-                                href={`https://github.com/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                GitHub repository
-                            </a>
-                        </p>
-                    )}
+                            {library.homepage && (
+                                <p className={styles.link}>
+                                    <a
+                                        href={library.homepage}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                    >
+                                        {library.homepage}
+                                    </a>
+                                </p>
+                            )}
+                        </div>
 
-                    {library.homepage && (
-                        <p className={styles.link}>
-                            <a
-                                href={library.homepage}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                {library.homepage}
-                            </a>
-                        </p>
-                    )}
-                </div>
-
-                {!!library.keywords?.length && (
-                    <p className={styles.keywords}>
-                        Keywords:{' '}
-                        {library.keywords.map((keyword, index, arr) => (
-                            <span key={index}>
-                                {keyword}
-                                {index < arr.length - 1 && ', '}
-                            </span>
-                        ))}
-                    </p>
-                )}
-            </div>
+                        {!!library.keywords?.length && (
+                            <p className={styles.keywords}>
+                                Keywords:{' '}
+                                {library.keywords.map((keyword, index, arr) => (
+                                    <span key={index}>
+                                        {keyword}
+                                        {index < arr.length - 1 && ', '}
+                                    </span>
+                                ))}
+                            </p>
+                        )}
+                    </>
+                }
+            >
+                <File
+                    name={library.name}
+                    version={version.version}
+                    filename={library.filename}
+                    files={version.files}
+                    sri={version.sri}
+                />
+            </Header>
 
             <Files
                 name={library.name}
@@ -199,7 +217,6 @@ export default ({
                 files={version.files}
                 sri={version.sri}
                 versions={library.versions}
-                featured={library.filename}
             />
         </>
     );

--- a/src/routes/library.page.tsx
+++ b/src/routes/library.page.tsx
@@ -51,7 +51,7 @@ const styles = {
             width: 100vw;
             left: 50%;
             transform: translateX(-50%);
-            background: ${theme.background.header};
+            background: ${theme.background.elevated};
             top: 0;
             bottom: 0;
             z-index: -1;

--- a/src/utils/jsx/footer.tsx
+++ b/src/utils/jsx/footer.tsx
@@ -24,7 +24,7 @@ const styles = {
             width: 100vw;
             left: 50%;
             transform: translateX(-50%);
-            background: ${theme.background.footer};
+            background: ${theme.background.elevated};
             top: 0;
             bottom: 0;
             z-index: -1;

--- a/src/utils/jsx/header.tsx
+++ b/src/utils/jsx/header.tsx
@@ -85,6 +85,13 @@ const styles = {
         strong {
             color: ${theme.text.brand};
         }
+
+        small {
+            color: ${theme.text.secondary};
+            font-family: ${theme.font.families.mono};
+            font-size: ${theme.font.body.size};
+            font-weight: ${theme.font.body.weight};
+        }
     `,
     prose: css`
         color: ${theme.text.secondary};

--- a/src/utils/jsx/header.tsx
+++ b/src/utils/jsx/header.tsx
@@ -8,6 +8,7 @@ import Grid from './grid.tsx';
 const styles = {
     header: css`
         position: relative;
+        isolation: isolate;
         display: flex;
         flex-direction: column;
     `,
@@ -100,6 +101,23 @@ const styles = {
             color: ${theme.text.primary};
         }
     `,
+    after: css`
+        position: relative;
+        isolation: isolate;
+        padding: ${theme.spacing(2, 0)};
+
+        &::before {
+            content: '';
+            position: absolute;
+            width: 100vw;
+            left: 50%;
+            transform: translateX(-50%);
+            background: ${theme.background.footer};
+            top: 0;
+            bottom: 0;
+            z-index: -1;
+        }
+    `,
 };
 
 /**
@@ -109,32 +127,42 @@ const styles = {
  * @param props.title The title of the page.
  * @param props.prose The prose content of the page.
  * @param props.fill If the header should grow to fill the parent.
- * @param props.children Optional additional content to render in the header.
+ * @param props.extra Optional additional content to render inside the header.
+ * @param props.children Optional additional content to render after the header.
  */
 export default ({
     title,
-    prose,
+    prose = "A free, open-source CDN for the web's most popular JavaScript, CSS, and font resources.",
     fill,
+    extra,
     children,
 }: {
     title: ReactNode;
-    prose: ReactNode;
+    prose?: ReactNode;
     fill?: boolean;
+    extra?: ReactNode;
     children?: ReactNode;
 }) => {
     return (
-        <div className={cx(styles.header, fill && styles.fill)}>
-            <Grid className={styles.background} height={fill ? undefined : 3} />
+        <>
+            <div className={cx(styles.header, fill && styles.fill)}>
+                <Grid
+                    className={styles.background}
+                    height={fill ? undefined : 3}
+                />
 
-            <div className={styles.content}>
-                <p className={styles.badge}>Powered by Cloudflare</p>
+                <div className={styles.content}>
+                    <p className={styles.badge}>Powered by Cloudflare</p>
 
-                <h1 className={styles.title}>{title}</h1>
+                    <h1 className={styles.title}>{title}</h1>
 
-                <p className={styles.prose}>{prose}</p>
+                    <p className={styles.prose}>{prose}</p>
 
-                {children}
+                    {extra}
+                </div>
             </div>
-        </div>
+
+            {children && <div className={styles.after}>{children}</div>}
+        </>
     );
 };

--- a/src/utils/jsx/header.tsx
+++ b/src/utils/jsx/header.tsx
@@ -37,8 +37,8 @@ const styles = {
         max-width: 100%;
         background: radial-gradient(
             ellipse at center,
-            rgb(from ${theme.background.body} r g b / 0.9) 0%,
-            rgb(from ${theme.background.body} r g b / 0) 100%
+            rgb(from ${theme.background.primary} r g b / 0.9) 0%,
+            rgb(from ${theme.background.primary} r g b / 0) 100%
         );
         padding: ${theme.spacing(4, 2)};
     `,
@@ -119,7 +119,7 @@ const styles = {
             width: 100vw;
             left: 50%;
             transform: translateX(-50%);
-            background: ${theme.background.footer};
+            background: ${theme.background.elevated};
             top: 0;
             bottom: 0;
             z-index: -1;

--- a/src/utils/jsx/islands/file.tsx
+++ b/src/utils/jsx/islands/file.tsx
@@ -1,0 +1,70 @@
+import { css } from '@emotion/css';
+import { useMemo } from 'react';
+
+import theme from '../../theme.ts';
+import Copy from '../copy.tsx';
+import createIsland from '../island.tsx';
+
+const styles = {
+    container: css`
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: ${theme.spacing(1)};
+    `,
+    url: css`
+        background: ${theme.background.body};
+        border-radius: ${theme.radius};
+        color: ${theme.text.primary};
+        font-family: ${theme.font.families.mono};
+        font-size: ${theme.font.small.size};
+        font-weight: ${theme.font.small.weight};
+        padding: ${theme.spacing(0.5, 1)};
+        flex: 1;
+    `,
+};
+
+/**
+ * Library version file island component to render the default file on the CDN for a library version.
+ *
+ * @param props Component props.
+ * @param props.name Library name.
+ * @param props.version Library version.
+ * @param props.filename Library default filename.
+ * @param props.files List of files for the library version.
+ * @param props.sri Map of file names to SRI hashes for the library version.
+ */
+const File = ({
+    name,
+    version,
+    filename,
+    files,
+    sri,
+}: {
+    name: string;
+    version: string;
+    filename?: string;
+    files: string[];
+    sri: Record<string, string>;
+}) => {
+    const file = useMemo(
+        () => files.find((f) => f === filename),
+        [files, filename],
+    );
+    return (
+        <div className={styles.container}>
+            <code className={styles.url}>
+                {`https://cdnjs.cloudflare.com/ajax/libs/${name}/${version}/${file ?? '...'}`}
+            </code>
+
+            <Copy
+                name={name}
+                version={version}
+                file={file ?? '...'}
+                sri={file ? sri[file] : undefined}
+            />
+        </div>
+    );
+};
+
+export default createIsland(File, 'file.tsx');

--- a/src/utils/jsx/islands/file.tsx
+++ b/src/utils/jsx/islands/file.tsx
@@ -13,7 +13,7 @@ const styles = {
         gap: ${theme.spacing(1)};
     `,
     url: css`
-        background: ${theme.background.body};
+        background: ${theme.background.primary};
         border-radius: ${theme.radius};
         color: ${theme.text.primary};
         font-family: ${theme.font.families.mono};

--- a/src/utils/jsx/islands/files.tsx
+++ b/src/utils/jsx/islands/files.tsx
@@ -48,7 +48,7 @@ const styles = {
         }
 
         select {
-            background: ${theme.background.navigation};
+            background: ${theme.background.elevated};
             color: ${theme.text.primary};
             cursor: pointer;
             padding: ${theme.spacing(0.5, 1)};
@@ -81,7 +81,7 @@ const styles = {
         align-items: center;
         gap: ${theme.spacing(0.5)};
         padding: ${theme.spacing(0.5, 1)};
-        background: ${theme.background.footer};
+        background: ${theme.background.elevated};
         border-radius: ${theme.radius};
 
         a {

--- a/src/utils/jsx/islands/files.tsx
+++ b/src/utils/jsx/islands/files.tsx
@@ -19,11 +19,12 @@ const styles = {
     toolbar: css`
         display: flex;
         flex-wrap: wrap;
-        align-items: baseline;
+        align-items: center;
         justify-content: space-between;
         gap: ${theme.spacing(1, 2)};
+        margin: ${theme.spacing(2, 0)};
     `,
-    url: css`
+    count: css`
         color: ${theme.text.secondary};
         font-size: ${theme.font.small.size};
         font-weight: ${theme.font.small.weight};
@@ -67,7 +68,7 @@ const styles = {
     list: css`
         list-style: none;
         padding: 0;
-        margin: ${theme.spacing(2, 0)};
+        margin: 0;
         transition: opacity ${theme.transition};
 
         @starting-style {
@@ -93,9 +94,6 @@ const styles = {
                 text-decoration: none;
             }
         }
-    `,
-    featured: css`
-        outline: 2px solid ${theme.background.brand};
     `,
 };
 
@@ -198,25 +196,16 @@ const File = ({
     version,
     file,
     sri,
-    featured = false,
     ...props
 }: {
     name: string;
     version: string;
     file: string;
     sri?: string;
-    featured?: boolean;
 } & HTMLAttributes<HTMLLIElement> &
     RefAttributes<HTMLLIElement>) => {
     return (
-        <li
-            {...props}
-            className={cx(
-                styles.file,
-                featured && styles.featured,
-                props.className,
-            )}
-        >
+        <li {...props} className={cx(styles.file, props.className)}>
             <a
                 href={`https://cdnjs.cloudflare.com/ajax/libs/${encodeURIComponent(name)}/${encodeURIComponent(version)}/${file}`}
                 target="_blank"
@@ -239,7 +228,6 @@ const File = ({
  * @param props.files List of files for the library version.
  * @param props.sri Map of file names to SRI hashes for the library version.
  * @param props.versions List of all versions for the library.
- * @param props.featured Featured file to highlight at the top of the list.
  */
 const Files = ({
     name,
@@ -247,28 +235,22 @@ const Files = ({
     files,
     sri,
     versions,
-    featured,
 }: {
     name: string;
     version: string;
     files: string[];
     sri: Record<string, string>;
     versions: string[];
-    featured?: string;
 }) => {
     const sortedFiles = useMemo(
         () =>
             [...files].sort((a, b) => {
-                if (a === featured) return -1;
-                if (b === featured) return 1;
-
                 const aDepth = a.split('/').length;
                 const bDepth = b.split('/').length;
                 if (aDepth !== bDepth) return aDepth - bDepth;
-
                 return a.localeCompare(b);
             }),
-        [files, featured],
+        [files],
     );
 
     const [listFiles, setListFiles] = useState(sortedFiles);
@@ -292,12 +274,19 @@ const Files = ({
         virtualizer.measure();
     }, [listFiles, virtualizer]);
 
+    const [total, setTotal] = useState(
+        listFiles.length.toLocaleString('en-US'),
+    );
+    useEffect(() => {
+        setTotal(listFiles.length.toLocaleString());
+    }, [listFiles.length]);
+
     return (
         <>
             <div className={styles.toolbar}>
-                <code className={styles.url}>
-                    {`https://cdnjs.cloudflare.com/ajax/libs/${name}/${version}/...`}
-                </code>
+                <p className={styles.count}>
+                    {total} file{listFiles.length !== 1 ? 's' : ''}
+                </p>
                 <Versions name={name} version={version} versions={versions} />
                 <Filter files={sortedFiles} onChange={setListFiles} />
             </div>
@@ -320,7 +309,6 @@ const Files = ({
                             version={version}
                             file={file}
                             sri={sri[file]}
-                            featured={file === featured}
                             style={{
                                 position: 'absolute',
                                 top: 0,

--- a/src/utils/jsx/islands/libraries.tsx
+++ b/src/utils/jsx/islands/libraries.tsx
@@ -5,6 +5,7 @@ import * as z from 'zod/mini';
 
 import theme from '../../theme.ts';
 import Copy from '../copy.tsx';
+import Header from '../header.tsx';
 import createIsland from '../island.tsx';
 import Search from '../search.tsx';
 
@@ -38,23 +39,7 @@ const styles = {
         display: flex;
         flex-direction: column;
         gap: ${theme.spacing(2)};
-        margin: ${theme.spacing(-2, 0, 2)};
         padding: ${theme.spacing(2, 0)};
-        position: relative;
-        isolation: isolate;
-        z-index: 1;
-
-        &::before {
-            content: '';
-            position: absolute;
-            width: 100vw;
-            left: 50%;
-            transform: translateX(-50%);
-            background: ${theme.background.header};
-            top: 0;
-            bottom: 0;
-            z-index: -1;
-        }
     `,
     found: css`
         color: ${theme.text.secondary};
@@ -72,7 +57,7 @@ const styles = {
     `,
     results: css`
         padding: 0;
-        margin: 0;
+        margin: ${theme.spacing(2, 0, 0)};
         list-style: none;
         transition: opacity ${theme.transition};
 
@@ -291,13 +276,22 @@ const Libraries = ({
 
     return (
         <>
-            <div className={styles.header}>
-                <Search value={search} onChange={setSearch} state={state} />
+            <Header
+                title={
+                    <>
+                        Browse <strong>cdnjs</strong>
+                    </>
+                }
+            >
+                <div className={styles.header}>
+                    <Search value={search} onChange={setSearch} state={state} />
 
-                <p className={styles.found}>
-                    Found <strong>{total}</strong> libraries available on cdnjs.
-                </p>
-            </div>
+                    <p className={styles.found}>
+                        Found <strong>{total}</strong> libraries available on
+                        cdnjs.
+                    </p>
+                </div>
+            </Header>
 
             <ul
                 ref={listRef}

--- a/src/utils/jsx/islands/libraries.tsx
+++ b/src/utils/jsx/islands/libraries.tsx
@@ -80,14 +80,14 @@ const styles = {
         flex-direction: column;
         gap: ${theme.spacing(1)};
         padding: ${theme.spacing(2)};
-        background: ${theme.background.footer};
+        background: ${theme.background.elevated};
         border-radius: ${theme.radius};
         position: relative;
         isolation: isolate;
         transition: background ${theme.transition};
 
         &:has(a:hover, a:focus) {
-            background: rgb(from ${theme.background.footer} r g b / 0.75);
+            background: rgb(from ${theme.background.elevated} r g b / 0.75);
         }
     `,
     name: css`

--- a/src/utils/jsx/islands/swagger.tsx
+++ b/src/utils/jsx/islands/swagger.tsx
@@ -9,7 +9,7 @@ import createIsland from '../island.tsx';
 
 const mixins = {
     pre: css`
-        background: ${theme.background.footer} !important;
+        background: ${theme.background.elevated} !important;
         color: ${theme.text.primary};
         padding: ${theme.spacing(1.5, 2)} !important;
         border-radius: ${theme.radius};
@@ -28,7 +28,7 @@ const mixins = {
         }
     `,
     code: css`
-        background: ${theme.background.body};
+        background: ${theme.background.primary};
         color: ${theme.text.primary};
         padding: ${theme.spacing(0.25, 0.75)};
         border-radius: ${theme.radius};
@@ -94,13 +94,16 @@ const styles = {
 
             /* Replace the default background of operation section headers. */
             .opblock .opblock-section-header {
-                background: ${theme.background.footer};
+                background: ${theme.background.primary};
                 box-shadow: none;
                 border-radius: ${theme.radius};
+                margin: ${theme.spacing(0, 1)};
+                padding: ${theme.spacing(1.5, 2, 0)};
+                min-height: 0;
             }
 
             /* Add a consistent indicator to the "Parameters" + "Responses" tabs. */
-            .opblock .opblock-section-header .tab-item h4 span,
+            .opblock .opblock-section-header .tab-item.active h4 span,
             .opblock .responses-wrapper .opblock-section-header h4 {
                 position: relative;
                 display: inline-block;
@@ -115,7 +118,8 @@ const styles = {
                     width: 100%;
                     height: ${theme.spacing(0.5)};
                     background: ${theme.background.brand};
-                    margin-top: ${theme.spacing(0.5)};
+                    border-radius: ${theme.radius};
+                    margin-top: ${theme.spacing(0.75)};
                     bottom: auto;
                     left: auto;
                 }
@@ -206,9 +210,9 @@ const styles = {
     `,
     wrapper: css`
         display: block;
-        border: ${theme.spacing(0.125)} solid ${theme.background.body};
+        border: ${theme.spacing(0.125)} solid ${theme.background.primary};
         border-radius: ${theme.radius};
-        background: ${theme.background.navigation};
+        background: ${theme.background.elevated};
         margin: 0 0 ${theme.spacing(1.5)};
         overflow: hidden;
     `,
@@ -217,7 +221,7 @@ const styles = {
         display: flex;
         align-items: center;
         gap: ${theme.spacing(1.5)};
-        background: ${theme.background.footer};
+        background: ${theme.background.elevated};
         cursor: pointer;
 
         > span:first-child {

--- a/src/utils/jsx/islands/swagger.tsx
+++ b/src/utils/jsx/islands/swagger.tsx
@@ -13,20 +13,26 @@ const mixins = {
         color: ${theme.text.primary};
         padding: ${theme.spacing(1.5, 2)} !important;
         border-radius: ${theme.radius};
-        font-size: ${theme.font.small.size};
-        font-weight: ${theme.font.small.weight};
         margin: 0;
         display: block;
         width: 100%;
         box-sizing: border-box;
         max-height: ${theme.spacing(50)};
         overflow: auto;
+
+        &,
+        code {
+            font-family: ${theme.font.families.mono};
+            font-size: ${theme.font.small.size};
+            font-weight: ${theme.font.small.weight};
+        }
     `,
     code: css`
         background: ${theme.background.body};
         color: ${theme.text.primary};
         padding: ${theme.spacing(0.25, 0.75)};
         border-radius: ${theme.radius};
+        font-family: ${theme.font.families.mono};
         font-size: ${theme.font.small.size};
         font-weight: ${theme.font.small.weight};
     `,
@@ -37,6 +43,8 @@ const mixins = {
 
 const styles = {
     container: css`
+        margin: ${theme.spacing(2, 0, 0)};
+
         .swagger-ui {
             pre {
                 ${mixins.pre};
@@ -142,8 +150,14 @@ const styles = {
             }
 
             /* Remove the duplicate model title from standalone schemas. */
-            section.models .model-box-control:has(.model-title) {
-                display: none;
+            section.models {
+                &.is-open {
+                    padding: 0;
+                }
+
+                .model-box-control:has(.model-title) {
+                    display: none;
+                }
             }
 
             /* Replace the default SVG with +/- for the toggles in models. */

--- a/src/utils/jsx/islands/typeahead.tsx
+++ b/src/utils/jsx/islands/typeahead.tsx
@@ -146,15 +146,14 @@ const styles = {
 };
 
 const Typeahead = ({ className }: { className?: string }) => {
-    const [state, setState] = useState<'idle' | 'loading' | 'failed'>(
-        'loading',
-    );
+    const [state, setState] = useState<'idle' | 'loading' | 'failed'>('idle');
     const [results, setResults] = useState<Result[]>([]);
     const [total, setTotal] = useState('0');
     const [queried, setQueried] = useState('');
     const [query, setQuery] = useState('');
     const [active, setActive] = useState(false);
     const abortRef = useRef<AbortController | null>(null);
+    const mountedRef = useRef(false);
 
     const runSearch = useCallback(async (search: string) => {
         const controller = new AbortController();
@@ -180,6 +179,11 @@ const Typeahead = ({ className }: { className?: string }) => {
     }, []);
 
     useEffect(() => {
+        if (!mountedRef.current) {
+            mountedRef.current = true;
+            return;
+        }
+
         const timer = setTimeout(() => runSearch(query), 300);
         return () => clearTimeout(timer);
     }, [runSearch, query]);
@@ -214,9 +218,12 @@ const Typeahead = ({ className }: { className?: string }) => {
                 }}
                 onBlur={() => setActive(false)}
                 onSubmit={() => {
-                    window.location.href = `/libraries?search=${encodeURIComponent(query)}&output=human`;
+                    window.location.href = query.length
+                        ? `/libraries?search=${encodeURIComponent(query)}&output=human`
+                        : '/libraries?output=human';
                 }}
                 state={state}
+                elevated
             />
 
             {active &&
@@ -244,7 +251,11 @@ const Typeahead = ({ className }: { className?: string }) => {
 
                             {state === 'idle' && results.length > 0 && (
                                 <a
-                                    href={`/libraries?search=${encodeURIComponent(queried)}&output=human`}
+                                    href={
+                                        queried.length
+                                            ? `/libraries?search=${encodeURIComponent(queried)}&output=human`
+                                            : '/libraries?output=human'
+                                    }
                                 >
                                     View all
                                 </a>

--- a/src/utils/jsx/islands/typeahead.tsx
+++ b/src/utils/jsx/islands/typeahead.tsx
@@ -38,10 +38,10 @@ const styles = {
     `,
     popover: css`
         position: absolute;
-        background: ${theme.background.footer};
+        background: ${theme.background.elevated};
         border-radius: ${theme.radius};
-        box-shadow: 0 0 ${theme.spacing(2)} ${theme.background.footer};
-        outline: ${theme.spacing(0.125)} solid ${theme.background.body};
+        box-shadow: 0 0 ${theme.spacing(2)} ${theme.background.elevated};
+        outline: ${theme.spacing(0.125)} solid ${theme.background.primary};
         padding: ${theme.spacing(1, 0)};
         margin: ${theme.spacing(1, 0, 0)};
         overflow: hidden;

--- a/src/utils/jsx/layout.tsx
+++ b/src/utils/jsx/layout.tsx
@@ -20,15 +20,11 @@ const styles = {
         }
     `,
     background: css`
-        background: linear-gradient(
-                ${theme.background.navigation} 45%,
-                ${theme.background.footer} 55%
-            )
-            fixed;
+        background: ${theme.background.elevated};
         color: ${theme.text.primary};
     `,
     main: css`
-        background: ${theme.background.body};
+        background: ${theme.background.primary};
         display: flex;
         flex-direction: column;
         min-height: 100vh;

--- a/src/utils/jsx/navigation.tsx
+++ b/src/utils/jsx/navigation.tsx
@@ -18,7 +18,7 @@ const styles = {
             width: 100vw;
             left: 50%;
             transform: translateX(-50%);
-            background: ${theme.background.navigation};
+            background: ${theme.background.elevated};
             top: 0;
             bottom: 0;
             z-index: -1;
@@ -92,9 +92,9 @@ const styles = {
         top: 100%;
         left: 0;
         right: 0;
-        background: ${theme.background.navigation};
+        background: ${theme.background.elevated};
         border-top: ${theme.spacing(0.25)} solid ${theme.background.brand};
-        border-bottom: ${theme.spacing(0.25)} solid ${theme.background.footer};
+        border-bottom: ${theme.spacing(0.25)} solid ${theme.background.elevated};
         display: flex;
         flex-direction: column;
         gap: ${theme.spacing(0.5)};

--- a/src/utils/jsx/search.tsx
+++ b/src/utils/jsx/search.tsx
@@ -11,7 +11,7 @@ const styles = {
         position: relative;
     `,
     input: css`
-        background: ${theme.background.footer};
+        background: ${theme.background.body};
         border: none;
         border-radius: ${theme.radius};
         color: ${theme.text.primary};
@@ -19,6 +19,10 @@ const styles = {
         font-weight: ${theme.font.body.weight};
         width: 100%;
         padding: ${theme.spacing(2, 6, 2, 2)};
+    `,
+    elevated: css`
+        background: ${theme.background.footer};
+        box-shadow: 0 0 ${theme.spacing(2)} ${theme.background.footer};
     `,
     icon: css`
         color: ${theme.text.primary};
@@ -39,7 +43,7 @@ const Search = ({
     onBlur,
     onSubmit,
     state,
-    className,
+    elevated,
 }: {
     value: string;
     onChange: (value: string) => void;
@@ -47,11 +51,11 @@ const Search = ({
     onBlur?: () => void;
     onSubmit?: () => void;
     state?: 'idle' | 'loading' | 'failed';
-    className?: string;
+    elevated?: boolean;
 }) => {
     return (
         <form
-            className={cx(styles.form, className)}
+            className={styles.form}
             onSubmit={(e) => {
                 e.preventDefault();
                 onSubmit?.();
@@ -66,7 +70,7 @@ const Search = ({
                 onBlur={onBlur}
                 placeholder="Search libraries on cdnjs..."
                 autoComplete="off"
-                className={styles.input}
+                className={cx(styles.input, elevated && styles.elevated)}
             />
             {
                 {

--- a/src/utils/jsx/search.tsx
+++ b/src/utils/jsx/search.tsx
@@ -11,7 +11,7 @@ const styles = {
         position: relative;
     `,
     input: css`
-        background: ${theme.background.body};
+        background: ${theme.background.primary};
         border: none;
         border-radius: ${theme.radius};
         color: ${theme.text.primary};
@@ -21,8 +21,8 @@ const styles = {
         padding: ${theme.spacing(2, 6, 2, 2)};
     `,
     elevated: css`
-        background: ${theme.background.footer};
-        box-shadow: 0 0 ${theme.spacing(2)} ${theme.background.footer};
+        background: ${theme.background.elevated};
+        box-shadow: 0 0 ${theme.spacing(2)} ${theme.background.elevated};
     `,
     icon: css`
         color: ${theme.text.primary};

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -9,10 +9,8 @@ export default {
         brand: '#d9643a',
     },
     background: {
-        body: '#454647',
-        navigation: '#343535',
-        header: '#3a3c3c',
-        footer: '#242525',
+        primary: '#454647',
+        elevated: '#242525',
         brand: '#d9643a',
     },
     status: {


### PR DESCRIPTION
## Type of Change

- **Routes:** All human output

## What issue does this relate to?

N/A

### What should this PR do?

Uses the header component consistently across all pages + reduces the number of background colors in the theme.

### What are the acceptance criteria?

All human output pages use the header component, backgrounds continue to visually look okay.
