### PR TITLE
Tweak request handling for website React output

### DIFF
--- a/src/routes/about.spec.ts
+++ b/src/routes/about.spec.ts
@@ -51,6 +51,9 @@ describe('/about', () => {
                 'public, max-age=21600',
             ); // 6 hours
         });
+        it('returns the correct status code', () => {
+            expect(response.status).to.eq(200);
+        });
         testWebsite(response);
     });
 });

--- a/src/routes/api.spec.ts
+++ b/src/routes/api.spec.ts
@@ -61,6 +61,9 @@ describe('/api', () => {
                 'public, max-age=21600',
             ); // 6 hours
         });
+        it('returns the correct status code', () => {
+            expect(response.status).to.eq(200);
+        });
         testWebsite(response);
     });
 });

--- a/src/routes/errors.spec.ts
+++ b/src/routes/errors.spec.ts
@@ -48,6 +48,9 @@ describe('/this-route-doesnt-exist', () => {
                 'public, max-age=3600',
             ); // 1 hour
         });
+        it('returns the correct status code', () => {
+            expect(response.status).to.eq(404);
+        });
         testWebsite(response);
     });
 });

--- a/src/routes/index.spec.ts
+++ b/src/routes/index.spec.ts
@@ -42,6 +42,9 @@ describe('/', () => {
                 'public, max-age=21600',
             ); // 6 hours
         });
+        it('returns the correct status code', () => {
+            expect(response.status).to.eq(200);
+        });
         testWebsite(response);
     });
 });

--- a/src/routes/libraries.spec.ts
+++ b/src/routes/libraries.spec.ts
@@ -39,7 +39,7 @@ describe('/libraries', () => {
         it('returns the correct Cache headers', () => {
             expect(response.headers.get('Cache-Control')).to.eq(
                 'public, max-age=21600',
-            ); // Six hours
+            ); // 6 hours
         });
         it('returns the correct status code', () => {
             expect(response.status).to.eq(200);
@@ -113,7 +113,10 @@ describe('/libraries', () => {
         it('returns the correct Cache headers', () => {
             expect(response.headers.get('Cache-Control')).to.eq(
                 'public, max-age=21600',
-            ); // Six hours
+            ); // 6 hours
+        });
+        it('returns the correct status code', () => {
+            expect(response.status).to.eq(200);
         });
         testWebsite(response);
     });
@@ -127,7 +130,7 @@ describe('/libraries', () => {
         it('returns the correct Cache headers', () => {
             expect(response.headers.get('Cache-Control')).to.eq(
                 'public, max-age=21600',
-            ); // Six hours
+            ); // 6 hours
         });
         it('returns the correct status code', () => {
             expect(response.status).to.eq(200);
@@ -159,7 +162,7 @@ describe('/libraries', () => {
         it('returns the correct Cache headers', () => {
             expect(response.headers.get('Cache-Control')).to.eq(
                 'public, max-age=21600',
-            ); // Six hours
+            ); // 6 hours
         });
         it('returns the correct status code', () => {
             expect(response.status).to.eq(200);
@@ -215,7 +218,7 @@ describe('/libraries', () => {
             it('returns the correct Cache headers', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=21600',
-                ); // Six hours
+                ); // 6 hours
             });
             it('returns the correct status code', () => {
                 expect(response.status).to.eq(200);
@@ -273,7 +276,7 @@ describe('/libraries', () => {
             it('returns the correct Cache headers', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=21600',
-                ); // Six hours
+                ); // 6 hours
             });
             it('returns the correct status code', () => {
                 expect(response.status).to.eq(200);
@@ -333,7 +336,7 @@ describe('/libraries', () => {
             it('returns the correct Cache headers', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=21600',
-                ); // Six hours
+                ); // 6 hours
             });
             it('returns the correct status code', () => {
                 expect(response.status).to.eq(200);
@@ -381,7 +384,7 @@ describe('/libraries', () => {
             it('returns the correct Cache headers', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=21600',
-                ); // Six hours
+                ); // 6 hours
             });
             it('returns the correct status code', () => {
                 expect(response.status).to.eq(200);
@@ -431,7 +434,7 @@ describe('/libraries', () => {
             it('returns the correct Cache headers', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=21600',
-                ); // Six hours
+                ); // 6 hours
             });
             it('returns the correct status code', () => {
                 expect(response.status).to.eq(200);
@@ -480,7 +483,7 @@ describe('/libraries', () => {
         it('returns the correct Cache headers', () => {
             expect(response.headers.get('Cache-Control')).to.eq(
                 'public, max-age=21600',
-            ); // Six hours
+            ); // 6 hours
         });
         it('returns the correct status code', () => {
             expect(response.status).to.eq(200);
@@ -581,7 +584,7 @@ describe('/libraries', () => {
             it('returns the correct Cache headers', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=21600',
-                ); // Six hours
+                ); // 6 hours
             });
             it('returns the correct status code', () => {
                 expect(response.status).to.eq(200);
@@ -639,7 +642,7 @@ describe('/libraries', () => {
             it('returns the correct Cache headers', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=21600',
-                ); // Six hours
+                ); // 6 hours
             });
             it('returns the correct status code', () => {
                 expect(response.status).to.eq(200);
@@ -674,7 +677,7 @@ describe('/libraries', () => {
             it('returns the correct Cache headers', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=21600',
-                ); // Six hours
+                ); // 6 hours
             });
             it('returns the correct status code', () => {
                 expect(response.status).to.eq(200);
@@ -716,7 +719,7 @@ describe('/libraries', () => {
                 it('returns the correct Cache headers', () => {
                     expect(response.headers.get('Cache-Control')).to.eq(
                         'public, max-age=21600',
-                    ); // Six hours
+                    ); // 6 hours
                 });
                 it('returns the correct status code', () => {
                     expect(response.status).to.eq(200);
@@ -780,7 +783,7 @@ describe('/libraries', () => {
                 it('returns the correct Cache headers', () => {
                     expect(response.headers.get('Cache-Control')).to.eq(
                         'public, max-age=21600',
-                    ); // Six hours
+                    ); // 6 hours
                 });
                 it('returns the correct status code', () => {
                     expect(response.status).to.eq(200);
@@ -844,7 +847,7 @@ describe('/libraries', () => {
                 it('returns the correct Cache headers', () => {
                     expect(response.headers.get('Cache-Control')).to.eq(
                         'public, max-age=21600',
-                    ); // Six hours
+                    ); // 6 hours
                 });
                 it('returns the correct status code', () => {
                     expect(response.status).to.eq(200);
@@ -910,7 +913,7 @@ describe('/libraries', () => {
             it('returns the correct Cache headers', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=21600',
-                ); // Six hours
+                ); // 6 hours
             });
             it('returns the correct status code', () => {
                 expect(response.status).to.eq(200);

--- a/src/routes/libraries.ts
+++ b/src/routes/libraries.ts
@@ -19,15 +19,19 @@ import {
  * @param ctx Request context.
  */
 const handleGetLibraries = async (ctx: Context) => {
-    // Get the index results
-    const searchFields = queryArray(ctx.req.queries('search_fields'));
+    // Get the index results, allowing search fields to be specified if this is an API request
+    const searchFields = isWebsite(ctx)
+        ? []
+        : queryArray(ctx.req.queries('search_fields'));
     const results = await libraries(
         ctx.req.query('search') || '',
         searchFields.includes('*') ? [] : searchFields,
     );
 
-    // Transform the results into our filtered array
-    const requestedFields = queryCheck(ctx.req.queries('fields'), false);
+    // Transform the results, allowing filtering to be applied if this is an API request
+    const requestedFields = isWebsite(ctx)
+        ? (field: string) => ['version', 'description', 'sri'].includes(field)
+        : queryCheck(ctx.req.queries('fields'), false);
     const response = results.map((hit) => ({
         // Always send back name & latest
         name: hit.name,
@@ -41,18 +45,14 @@ const handleGetLibraries = async (ctx: Context) => {
                   hit.filename
                 : null,
         // Send back whatever else was requested, only send all if '*' explicitly included
-        // But, always include some fields for website requests
-        ...filter(
-            hit,
-            (field) =>
-                (isWebsite(ctx) &&
-                    ['version', 'description', 'sri'].includes(field)) ||
-                requestedFields(field),
-        ),
+        ...filter(hit, requestedFields),
     }));
 
-    // If they want less data, allow that
-    const limit = ctx.req.query('limit') && Number(ctx.req.query('limit'));
+    // Get the trimmed response, allowing a limit to be applied if this is an API request
+    const limit =
+        !isWebsite(ctx) &&
+        ctx.req.query('limit') &&
+        Number(ctx.req.query('limit'));
     const trimmed = limit ? response.slice(0, limit) : response;
 
     // Set a 6 hour life on this response

--- a/src/routes/library.spec.ts
+++ b/src/routes/library.spec.ts
@@ -90,6 +90,9 @@ describe('/libraries/:library/:version', () => {
                         'public, max-age=30672000, immutable',
                     ); // 355 days
                 });
+                it('returns the correct status code', () => {
+                    expect(response.status).to.eq(200);
+                });
                 testWebsite(response);
             });
 
@@ -358,6 +361,9 @@ describe('/libraries/:library/:version', () => {
                         'public, max-age=3600',
                     ); // 1 hour
                 });
+                it('returns the correct status code', () => {
+                    expect(response.status).to.eq(404);
+                });
                 testWebsite(response);
             });
         });
@@ -405,6 +411,9 @@ describe('/libraries/:library/:version', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=3600',
                 ); // 1 hour
+            });
+            it('returns the correct status code', () => {
+                expect(response.status).to.eq(404);
             });
             testWebsite(response);
         });
@@ -818,6 +827,9 @@ describe('/libraries/:library', () => {
                 expect(response.headers.get('Cache-Control')).to.eq(
                     'public, max-age=3600',
                 ); // 1 hour
+            });
+            it('returns the correct status code', () => {
+                expect(response.status).to.eq(404);
             });
             testWebsite(response);
         });

--- a/src/routes/library.spec.ts
+++ b/src/routes/library.spec.ts
@@ -87,8 +87,8 @@ describe('/libraries/:library/:version', () => {
                 testCors(path, response);
                 it('returns the correct Cache headers', () => {
                     expect(response.headers.get('Cache-Control')).to.eq(
-                        'public, max-age=30672000, immutable',
-                    ); // 355 days
+                        'public, max-age=21600',
+                    ); // 6 hours
                 });
                 it('returns the correct status code', () => {
                     expect(response.status).to.eq(200);

--- a/src/routes/library.ts
+++ b/src/routes/library.ts
@@ -125,9 +125,14 @@ const handleGetLibraryVersion = async (ctx: Context) => {
         );
     }
 
-    // Set a 355 day (same as CDN) life on this response
-    // This is also immutable as a version will never change
-    withCache(ctx, 355 * 24 * 60 * 60, true);
+    if (isWebsite(ctx)) {
+        // Set a 6 hour life on this response
+        withCache(ctx, 6 * 60 * 60);
+    } else {
+        // Set a 355 day (same as CDN) life on this response
+        // This is also immutable as a version will never change
+        withCache(ctx, 355 * 24 * 60 * 60, true);
+    }
 
     // Send the response
     return respond<LibraryVersionResponse>(ctx, response, async ({ data }) => {

--- a/src/routes/library.ts
+++ b/src/routes/library.ts
@@ -99,7 +99,9 @@ const handleGetLibraryVersion = async (ctx: Context) => {
     if (!version) return notFound(ctx, 'Version');
 
     // Generate the initial filtered response (without SRI data)
-    const requestedFields = queryCheck(ctx.req.queries('fields'));
+    const requestedFields = isWebsite(ctx)
+        ? (field: string) => ['version', 'files', 'sri'].includes(field)
+        : queryCheck(ctx.req.queries('fields'));
     const response: LibraryVersionResponse = filter(
         {
             name: lib.name,
@@ -157,6 +159,14 @@ const handleGetLibrary = async (ctx: Context) => {
         throw err;
     });
     if (!lib) return notFound(ctx, 'Library');
+
+    // Redirect to the version endpoint for website requests
+    if (isWebsite(ctx)) {
+        // Set a 6 hour life on this response
+        withCache(ctx, 6 * 60 * 60);
+
+        return ctx.redirect(`/libraries/${lib.name}/${lib.version}`);
+    }
 
     // Generate the initial filtered response (without SRI, versions or assets data)
     const requestedFields = queryCheck(ctx.req.queries('fields'));
@@ -247,11 +257,6 @@ const handleGetLibrary = async (ctx: Context) => {
 
     // Set a 6 hour life on this response
     withCache(ctx, 6 * 60 * 60);
-
-    // Redirect to the version endpoint for website requests
-    if (isWebsite(ctx)) {
-        return ctx.redirect(`/libraries/${lib.name}/${lib.version}`);
-    }
 
     // Send the response
     return respond<LibraryResponse>(ctx, response);

--- a/src/routes/stats.spec.ts
+++ b/src/routes/stats.spec.ts
@@ -65,8 +65,11 @@ describe('/stats', () => {
         testCors(path, response);
         it('returns the correct Cache headers', () => {
             expect(response.headers.get('Cache-Control')).to.eq(
-                'public, max-age=21600',
-            ); // 6 hours
+                'public, max-age=3600',
+            ); // 1 hour
+        });
+        it('returns the correct status code', () => {
+            expect(response.status).to.eq(404);
         });
         testWebsite(response);
     });

--- a/src/routes/stats.ts
+++ b/src/routes/stats.ts
@@ -5,7 +5,7 @@ import * as z from 'zod';
 import filter from '../utils/filter.ts';
 import { libraries } from '../utils/metadata.ts';
 import { queryCheck } from '../utils/query.ts';
-import respond, { withCache } from '../utils/respond.ts';
+import respond, { isWebsite, notFound, withCache } from '../utils/respond.ts';
 
 import { type StatsResponse, statsResponseSchema } from './stats.schema.ts';
 
@@ -15,6 +15,11 @@ import { type StatsResponse, statsResponseSchema } from './stats.schema.ts';
  * @param ctx Request context.
  */
 const handleGetStats = async (ctx: Context) => {
+    // Make this an API-only endpoint, no React page
+    if (isWebsite(ctx)) {
+        return notFound(ctx, 'Endpoint');
+    }
+
     const libs = await libraries();
     const response: StatsResponse = filter(
         {

--- a/src/routes/whitelist.spec.ts
+++ b/src/routes/whitelist.spec.ts
@@ -85,8 +85,11 @@ describe('/whitelist', () => {
         testCors(path, response);
         it('returns the correct Cache headers', () => {
             expect(response.headers.get('Cache-Control')).to.eq(
-                'public, max-age=21600',
-            ); // 6 hours
+                'public, max-age=3600',
+            ); // 1 hour
+        });
+        it('returns the correct status code', () => {
+            expect(response.status).to.eq(404);
         });
         testWebsite(response);
     });

--- a/src/routes/whitelist.ts
+++ b/src/routes/whitelist.ts
@@ -5,7 +5,7 @@ import * as z from 'zod';
 import files from '../utils/files.ts';
 import filter from '../utils/filter.ts';
 import { queryCheck } from '../utils/query.ts';
-import respond, { withCache } from '../utils/respond.ts';
+import respond, { isWebsite, notFound, withCache } from '../utils/respond.ts';
 
 import {
     type WhitelistResponse,
@@ -18,6 +18,11 @@ import {
  * @param ctx Request context.
  */
 const handleGetWhitelist = (ctx: Context) => {
+    // Make this an API-only endpoint, no React page
+    if (isWebsite(ctx)) {
+        return notFound(ctx, 'Endpoint');
+    }
+
     // Generate the filtered response
     const response: WhitelistResponse = filter(
         {


### PR DESCRIPTION
## Type of Change

- **Routes:** /whitelist, /stats, /libraries, /libraries/:library/:version

## What issue does this relate to?

N/A

### What should this PR do?

Applies a few tweaks to better handle website React output requests, disabling the /whitelist + /stats endpoints as they do not have pages, ensuring any website responses have a relatively short cache lifetime, and disabling the filter query parameter that could cause pages to fail to render.

### What are the acceptance criteria?

Website React output continues to work.