### PR TITLE
Fix hydration errors in libraries header grid + typeahead

### DIFF
--- a/src/utils/island.ts
+++ b/src/utils/island.ts
@@ -19,6 +19,11 @@ const parseIslandProps = <T>(root: Element): T | undefined => {
     }
 };
 
+const parseIslandPrefix = (root: Element): string | undefined => {
+    const prefix = root.getAttribute('data-island-prefix');
+    return prefix ? prefix : undefined;
+};
+
 /**
  * Hydrate every server-rendered instance of an island by name.
  *
@@ -41,7 +46,13 @@ const hydrateIsland = <T extends Record<string, unknown>>(
             continue;
         }
 
+        const identifierPrefix = parseIslandPrefix(node);
+        if (identifierPrefix === undefined) {
+            continue;
+        }
+
         hydrateRoot(node, createElement(component, props), {
+            identifierPrefix,
             onRecoverableError(error, errorInfo) {
                 console.error(
                     `[island:${name}] hydration recoverable error`,
@@ -50,6 +61,7 @@ const hydrateIsland = <T extends Record<string, unknown>>(
                     {
                         props,
                         node,
+                        identifierPrefix,
                     },
                 );
             },

--- a/src/utils/island.ts
+++ b/src/utils/island.ts
@@ -41,7 +41,19 @@ const hydrateIsland = <T extends Record<string, unknown>>(
             continue;
         }
 
-        hydrateRoot(node, createElement(component, props));
+        hydrateRoot(node, createElement(component, props), {
+            onRecoverableError(error, errorInfo) {
+                console.error(
+                    `[island:${name}] hydration recoverable error`,
+                    error,
+                    errorInfo.componentStack,
+                    {
+                        props,
+                        node,
+                    },
+                );
+            },
+        });
     }
 };
 

--- a/src/utils/jsx/grid.tsx
+++ b/src/utils/jsx/grid.tsx
@@ -1,10 +1,18 @@
 import { css, keyframes } from '@emotion/css';
+import { useId, useMemo } from 'react';
 
 const size = 75;
 const cols = 16;
 const rows = 9;
 
-const random = (min: number, max: number) => min + Math.random() * (max - min);
+// https://thebookofshaders.com/10/
+const noise = (seed: number, salt: number) => {
+    const value = Math.sin((seed + salt) * 12.9898) * 43758.5453123;
+    return value - Math.floor(value);
+};
+
+const random = (seed: number, salt: number, min: number, max: number) =>
+    min + noise(seed, salt) * (max - min);
 
 const dp = (val: number, places: number) =>
     Math.round((val + Number.EPSILON) * 10 ** places) / 10 ** places;
@@ -18,85 +26,113 @@ const path = (points: number[]) =>
         })
         .join(' L ')}`;
 
-// Decide which points are active and will be connected to their neighbours.
-const active = Array.from({ length: cols * rows }, (_, point) => {
-    const col = point % cols;
-    const row = Math.floor(point / cols);
+const grid = (id: string) => {
+    // Hash the id from React to generate a numeric seed for randomness.
+    const seed =
+        id.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0) %
+        (2 ** 31 - 1);
 
-    const edge = col === 0 || col === cols - 1 || row === 0 || row === rows - 1;
-    return Math.random() < (edge ? 0.3 : 0.5);
-});
+    // Decide which points are active and will be connected to their neighbours.
+    const active = Array.from({ length: cols * rows }, (_, point) => {
+        const col = point % cols;
+        const row = Math.floor(point / cols);
 
-// Connect the active points to their neighbours (right, down + neighbours below).
-const connections = active.reduce((acc, val, point) => {
-    if (!val) return acc;
+        const edge =
+            col === 0 || col === cols - 1 || row === 0 || row === rows - 1;
+        return noise(seed, 1000 + point) < (edge ? 0.3 : 0.5);
+    });
 
-    const col = point % cols;
-    const row = Math.floor(point / cols);
+    // Connect the active points to their neighbours (right, down + neighbours below).
+    const connections = active.reduce((acc, val, point) => {
+        if (!val) return acc;
 
-    // Connect to the right neighbour if it's active.
-    if (col < cols - 1 && active[point + 1]) {
-        acc.push([point, point + 1]);
-    }
+        const col = point % cols;
+        const row = Math.floor(point / cols);
 
-    // Connect to the bottom neighbour if it's active.
-    if (row < rows - 1 && active[point + cols]) {
-        acc.push([point, point + cols]);
-    }
-
-    // Only sometimes connect to the diagonal neighbours, when immediately below is not active.
-    if (Math.random() < 0.5 && row < rows - 1 && !active[point + cols]) {
-        // Connect to the bottom-right neighbour if it's active,
-        if (col < cols - 1 && active[point + cols + 1]) {
-            acc.push([point, point + cols, point + cols + 1]);
+        // Connect to the right neighbour if it's active.
+        if (col < cols - 1 && active[point + 1]) {
+            acc.push([point, point + 1]);
         }
 
-        // Connect to the bottom-left neighbour if it's active.
-        if (col > 0 && active[point + cols - 1]) {
-            acc.push([point, point + cols, point + cols - 1]);
+        // Connect to the bottom neighbour if it's active.
+        if (row < rows - 1 && active[point + cols]) {
+            acc.push([point, point + cols]);
         }
-    }
 
-    return acc;
-}, [] as number[][]);
+        // Only sometimes connect to the diagonal neighbours, when immediately below is not active.
+        if (
+            noise(seed, 2000 + point) < 0.5 &&
+            row < rows - 1 &&
+            !active[point + cols]
+        ) {
+            // Connect to the bottom-right neighbour if it's active,
+            if (col < cols - 1 && active[point + cols + 1]) {
+                acc.push([point, point + cols, point + cols + 1]);
+            }
 
-// Assign animated requests to move along the connections
-const requests = connections.reduce(
-    (acc, points) => {
-        // Only sometimes send a request from the start of the connection to the end.
-        if (Math.random() < 0.5) {
-            const duration = dp(random(2, 5), 2) * (points.length - 1);
-            const delay = dp(random(-duration, 0), 2);
-            acc.push([points, duration, delay]);
-
-            // Only sometimes also send a request from the end of the connection to the start.
-            if (Math.random() < 0.3) {
-                const duration = dp(random(2, 5), 2) * (points.length - 1);
-                const delay = dp(random(-duration, 0), 2);
-                acc.push([[...points].reverse(), duration, delay]);
+            // Connect to the bottom-left neighbour if it's active.
+            if (col > 0 && active[point + cols - 1]) {
+                acc.push([point, point + cols, point + cols - 1]);
             }
         }
 
         return acc;
-    },
-    [] as [number[], number, number][],
-);
+    }, [] as number[][]);
 
-// Check how many connections each active point has
-const vias = connections.reduce(
-    (acc, points) => {
-        const start = points[0];
-        if (start === undefined) return acc;
-        acc[start] = (acc[start] ?? 0) + 1;
+    // Assign animated requests to move along the connections.
+    const requests = connections.reduce(
+        (acc, points, connectionIdx) => {
+            // Only sometimes send a request from the start of the connection to the end.
+            if (noise(seed, 3000 + connectionIdx) < 0.5) {
+                const duration =
+                    dp(random(seed, 4000 + connectionIdx, 2, 5), 2) *
+                    (points.length - 1);
+                const delay = dp(
+                    random(seed, 5000 + connectionIdx, -duration, 0),
+                    2,
+                );
+                acc.push([points, duration, delay]);
 
-        const end = points[points.length - 1];
-        if (end === undefined) return acc;
-        acc[end] = (acc[end] ?? 0) + 1;
+                // Only sometimes also send a request from the end of the connection to the start.
+                if (noise(seed, 6000 + connectionIdx) < 0.3) {
+                    const reverseDuration =
+                        dp(random(seed, 7000 + connectionIdx, 2, 5), 2) *
+                        (points.length - 1);
+                    const reverseDelay = dp(
+                        random(seed, 8000 + connectionIdx, -reverseDuration, 0),
+                        2,
+                    );
+                    acc.push([
+                        [...points].reverse(),
+                        reverseDuration,
+                        reverseDelay,
+                    ]);
+                }
+            }
 
-        return acc;
-    },
-    Array.from({ length: cols * rows }, () => 0),
-);
+            return acc;
+        },
+        [] as [number[], number, number][],
+    );
+
+    // Check how many connections each active point has.
+    const vias = connections.reduce(
+        (acc, points) => {
+            const start = points[0];
+            if (start === undefined) return acc;
+            acc[start] = (acc[start] ?? 0) + 1;
+
+            const end = points[points.length - 1];
+            if (end === undefined) return acc;
+            acc[end] = (acc[end] ?? 0) + 1;
+
+            return acc;
+        },
+        Array.from({ length: cols * rows }, () => 0),
+    );
+
+    return { connections, requests, vias };
+};
 
 const anims = {
     hub: keyframes`
@@ -201,109 +237,114 @@ export default ({
     width?: number;
     height?: number;
     className?: string;
-}) => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        // The base viewBox would be `0 0 ${cols * size} ${rows * size}`
-        // But, we want to center that around whatever width and height are passed in
-        viewBox={`${(cols * size - width * size) / 2} ${(rows * size - height * size) / 2} ${width * size} ${height * size}`}
-        preserveAspectRatio="xMidYMid slice"
-        aria-hidden="true"
-        className={className}
-    >
-        <g>
-            {Array.from({ length: cols * rows }, (_, point) => {
-                const col = point % cols;
-                const row = Math.floor(point / cols);
+}) => {
+    const id = useId();
+    const { connections, requests, vias } = useMemo(() => grid(id), [id]);
 
-                return (
-                    <circle
-                        key={point}
-                        cx={col * size}
-                        cy={row * size}
-                        r={1}
-                        className={styles.grid}
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            // The base viewBox would be `0 0 ${cols * size} ${rows * size}`
+            // But, we want to center that around whatever width and height are passed in
+            viewBox={`${(cols * size - width * size) / 2} ${(rows * size - height * size) / 2} ${width * size} ${height * size}`}
+            preserveAspectRatio="xMidYMid slice"
+            aria-hidden="true"
+            className={className}
+        >
+            <g>
+                {Array.from({ length: cols * rows }, (_, point) => {
+                    const col = point % cols;
+                    const row = Math.floor(point / cols);
+
+                    return (
+                        <circle
+                            key={point}
+                            cx={col * size}
+                            cy={row * size}
+                            r={1}
+                            className={styles.grid}
+                        />
+                    );
+                })}
+            </g>
+
+            <g>
+                {connections.map((points, idx) => (
+                    <path
+                        key={idx}
+                        d={path(points)}
+                        className={styles.connection}
                     />
-                );
-            })}
-        </g>
+                ))}
+            </g>
 
-        <g>
-            {connections.map((points, idx) => (
-                <path
-                    key={idx}
-                    d={path(points)}
-                    className={styles.connection}
-                />
-            ))}
-        </g>
+            <g>
+                {vias.map((via, point) => {
+                    if (!via) return null;
 
-        <g>
-            {vias.map((via, point) => {
-                if (!via) return null;
+                    const col = point % cols;
+                    const row = Math.floor(point / cols);
+                    const hub = via > 2;
+                    const duration = hub ? 2 : 4;
+                    const stagger = -dp((point * 0.4) % duration, 2);
 
-                const col = point % cols;
-                const row = Math.floor(point / cols);
-                const hub = via > 2;
-                const duration = hub ? 2 : 4;
-                const stagger = -dp((point * 0.4) % duration, 2);
-
-                return (
-                    <g key={point}>
-                        {hub && (
+                    return (
+                        <g key={point}>
+                            {hub && (
+                                <circle
+                                    cx={col * size}
+                                    cy={row * size}
+                                    r={8}
+                                    className={styles.hub}
+                                    style={{
+                                        animationDuration: '3.5s',
+                                        animationDelay: `${stagger}s`,
+                                    }}
+                                />
+                            )}
                             <circle
                                 cx={col * size}
                                 cy={row * size}
-                                r={8}
-                                className={styles.hub}
+                                r={hub ? 4 : 2}
+                                className={styles.dot}
                                 style={{
-                                    animationDuration: '3.5s',
+                                    animationDuration: `${duration}s`,
                                     animationDelay: `${stagger}s`,
                                 }}
                             />
-                        )}
+                        </g>
+                    );
+                })}
+            </g>
+
+            <g>
+                {requests.map(([points, duration, delay], idx) => (
+                    <g key={idx}>
                         <circle
-                            cx={col * size}
-                            cy={row * size}
-                            r={hub ? 4 : 2}
-                            className={styles.dot}
+                            cx={0}
+                            cy={0}
+                            r={5}
+                            className={styles.request}
                             style={{
+                                offsetPath: `path('${path(points)}')`,
                                 animationDuration: `${duration}s`,
-                                animationDelay: `${stagger}s`,
+                                animationDelay: `${delay}s`,
+                            }}
+                        />
+                        <circle
+                            cx={0}
+                            cy={0}
+                            r={2}
+                            className={styles.request}
+                            style={{
+                                offsetPath: `path('${path(points)}')`,
+                                animationDuration: `${duration}s`,
+                                animationDelay: `${delay}s`,
                             }}
                         />
                     </g>
-                );
-            })}
-        </g>
-
-        <g>
-            {requests.map(([points, duration, delay], idx) => (
-                <g key={idx}>
-                    <circle
-                        cx={0}
-                        cy={0}
-                        r={5}
-                        className={styles.request}
-                        style={{
-                            offsetPath: `path('${path(points)}')`,
-                            animationDuration: `${duration}s`,
-                            animationDelay: `${delay}s`,
-                        }}
-                    />
-                    <circle
-                        cx={0}
-                        cy={0}
-                        r={2}
-                        className={styles.request}
-                        style={{
-                            offsetPath: `path('${path(points)}')`,
-                            animationDuration: `${duration}s`,
-                            animationDelay: `${delay}s`,
-                        }}
-                    />
-                </g>
-            ))}
-        </g>
-    </svg>
-);
+                ))}
+            </g>
+        </svg>
+    );
+};

--- a/src/utils/jsx/island.tsx
+++ b/src/utils/jsx/island.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { env } from 'cloudflare:workers';
 import { type ComponentType, createContext, useContext, useId } from 'react';
+import { renderToString } from 'react-dom/server';
 import * as z from 'zod';
 
 const manifestSchema = z.record(
@@ -72,6 +73,7 @@ const Island = <T extends object>({
 }) => {
     const instanceId = useId().replaceAll(':', '');
     const propsScriptId = `island-props-${name}-${instanceId}`;
+    const identifierPrefix = `island-${name}-${instanceId}-`;
 
     const { manifest } = useContext(IslandContext) ?? {};
     if (!manifest) {
@@ -85,15 +87,19 @@ const Island = <T extends object>({
         throw new Error(`Missing manifest entry for island "${name}"`);
     }
 
+    const islandHtml = renderToString(<Component {...props} />, {
+        identifierPrefix,
+    });
+
     return (
         <>
             <div
                 className={styles.island}
                 data-island={name}
                 data-island-props={propsScriptId}
-            >
-                <Component {...props} />
-            </div>
+                data-island-prefix={identifierPrefix}
+                dangerouslySetInnerHTML={{ __html: islandHtml }}
+            />
 
             <script
                 id={propsScriptId}

--- a/src/utils/jsx/island.tsx
+++ b/src/utils/jsx/island.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { cache, css } from '@emotion/css';
 import { env } from 'cloudflare:workers';
 import { type ComponentType, createContext, useContext, useId } from 'react';
 import { renderToString } from 'react-dom/server';
@@ -48,6 +48,43 @@ const serializeProps = (props: object) =>
         .replaceAll('\u2028', '\\u2028')
         .replaceAll('\u2029', '\\u2029');
 
+const renderIsland = <T extends object>(
+    Component: ComponentType<T>,
+    props: T,
+    identifierPrefix: string,
+) => {
+    const classNames =
+        'className' in props && typeof props.className === 'string'
+            ? props.className
+                  .split(/\s+/)
+                  .map((value) => value.trim())
+                  .filter((value) => value.length > 0)
+            : [];
+    const masked = new Map<string, string>();
+
+    // Isolated island bundles do not register parent-level Emotion classes, so mask
+    // those registrations during island SSR to keep cx() class merging behavior aligned.
+    for (const className of classNames) {
+        const cssText = cache.registered[className];
+        if (typeof cssText !== 'string') {
+            continue;
+        }
+
+        masked.set(className, cssText);
+        cache.registered[className] = undefined;
+    }
+
+    try {
+        return renderToString(<Component {...props} />, {
+            identifierPrefix,
+        });
+    } finally {
+        for (const [className, cssText] of masked.entries()) {
+            cache.registered[className] = cssText;
+        }
+    }
+};
+
 const styles = {
     island: css`
         display: contents;
@@ -87,9 +124,7 @@ const Island = <T extends object>({
         throw new Error(`Missing manifest entry for island "${name}"`);
     }
 
-    const islandHtml = renderToString(<Component {...props} />, {
-        identifierPrefix,
-    });
+    const islandHtml = renderIsland(Component, props, identifierPrefix);
 
     return (
         <>

--- a/vite.client.config.ts
+++ b/vite.client.config.ts
@@ -1,10 +1,13 @@
+import MagicString from 'magic-string';
 import { existsSync, globSync, mkdirSync, rmSync } from 'node:fs';
 import { basename, extname, resolve } from 'node:path';
-import { defineConfig } from 'vite';
+import { defineConfig, normalizePath } from 'vite';
 
 const outputDirectory = resolve('dist-client');
 const virtualEntryPrefix = 'virtual:island-entry:';
 const hydrationRuntimePath = resolve('src/utils/island.ts');
+
+const isDev = process.env.WRANGLER_COMMAND === 'dev';
 
 const isCssImport = (source: string) => /\.css(?:$|\?)/.test(source);
 
@@ -29,7 +32,7 @@ const islandEntryByName = new Map(
     islandEntries.map((entry) => [entry.name, entry]),
 );
 const islandEntryByPath = new Map(
-    islandEntries.map((entry) => [entry.path, entry]),
+    islandEntries.map((entry) => [normalizePath(entry.path), entry]),
 );
 
 const parseCreateIslandDeclaration = (source: string) => {
@@ -49,6 +52,11 @@ const parseCreateIslandDeclaration = (source: string) => {
 
 export default defineConfig({
     publicDir: false,
+    define: {
+        'process.env.NODE_ENV': JSON.stringify(
+            isDev ? 'development' : 'production',
+        ),
+    },
     plugins: [
         {
             name: 'raw-css-imports',
@@ -77,7 +85,7 @@ export default defineConfig({
             },
             // Strip the SSR wrapper from island modules in the client build.
             transform(code, id) {
-                const entry = islandEntryByPath.get(id);
+                const entry = islandEntryByPath.get(normalizePath(id));
                 if (!entry) {
                     return null;
                 }
@@ -99,15 +107,40 @@ export default defineConfig({
                     );
                 }
 
-                return code
-                    .replace(
-                        declaration.fullMatch,
-                        `export default ${declaration.componentReference};`,
-                    )
-                    .replace(
-                        /import\s+(?:createIsland\s+)?from\s+['"]\.\.\/island\.tsx['"];?\n?/g,
-                        '',
+                const transformed = new MagicString(code);
+                const declarationStart = code.indexOf(declaration.fullMatch);
+                if (declarationStart === -1) {
+                    throw new Error(
+                        `Failed to locate createIsland declaration in "${id}" for sourcemap transform.`,
                     );
+                }
+
+                transformed.overwrite(
+                    declarationStart,
+                    declarationStart + declaration.fullMatch.length,
+                    `export default ${declaration.componentReference};`,
+                );
+
+                for (const match of code.matchAll(
+                    /import\s+(?:createIsland\s+)?from\s+['"]\.\.\/island\.tsx['"];?\n?/g,
+                )) {
+                    if (match.index === undefined) {
+                        continue;
+                    }
+                    transformed.remove(
+                        match.index,
+                        match.index + match[0].length,
+                    );
+                }
+
+                return {
+                    code: transformed.toString(),
+                    map: transformed.generateMap({
+                        hires: true,
+                        source: id,
+                        includeContent: true,
+                    }),
+                };
             },
             // Generate one virtual hydration entry per island source file.
             load(id) {
@@ -137,6 +170,7 @@ export default defineConfig({
         outDir: outputDirectory,
         emptyOutDir: true,
         sourcemap: true,
+        minify: isDev ? false : undefined,
         manifest: 'islands/manifest.json',
         rollupOptions: {
             // Generate a separate client entry for each island, based on the file name.
@@ -153,13 +187,12 @@ export default defineConfig({
                 assetFileNames: 'islands/assets/[name]-[hash][extname]',
                 // Share the core React hydration code across all islands as a separate chunk.
                 manualChunks(id) {
-                    const normalizedId = id.replaceAll('\\', '/');
+                    const normalizedId = normalizePath(id);
 
                     if (
                         normalizedId.includes('/node_modules/react/') ||
                         normalizedId.includes('/node_modules/react-dom/') ||
-                        normalizedId ===
-                            hydrationRuntimePath.replaceAll('\\', '/')
+                        normalizedId === normalizePath(hydrationRuntimePath)
                     ) {
                         return 'hydration-runtime';
                     }


### PR DESCRIPTION
## Type of Change

- **Routes:** /, /libraries
- **Utilities:** Islands

## What issue does this relate to?

N/A

### What should this PR do?

Updates the island rendering logic to be more consistently stable across the server and client, fixing a hydration error on the libraries page with the randomness in the header grid background, and on the homepage with class name composition in the typeahead box.

### What are the acceptance criteria?

No hydration errors logged on pages.